### PR TITLE
[hlm-699]: Dockerfile path not needed for db

### DIFF
--- a/build/build-config.yml
+++ b/build/build-config.yml
@@ -29,4 +29,3 @@ config:
         dockerfile: "build/maven/Dockerfile"
       - work-dir: "health-services/product/src/main/resources/db"
         image-name: "product-db"
-        dockerfile: "build/maven/Dockerfile"


### PR DESCRIPTION
Will take work-dir by default