### PR TITLE
Added case insensitive search for project name

### DIFF
--- a/health-services/project/src/main/java/org/egov/project/repository/querybuilder/ProjectAddressQueryBuilder.java
+++ b/health-services/project/src/main/java/org/egov/project/repository/querybuilder/ProjectAddressQueryBuilder.java
@@ -78,8 +78,8 @@ public class ProjectAddressQueryBuilder {
 
             if (StringUtils.isNotBlank(project.getName())) {
                 addClauseIfRequired(preparedStmtList, queryBuilder);
-                queryBuilder.append(" prj.name LIKE ? ");
-                preparedStmtList.add('%' + project.getName() + '%');
+                queryBuilder.append(" LOWER(prj.name) LIKE ? ");
+                preparedStmtList.add('%' + project.getName().trim().toLowerCase() + '%');
             }
 
             if (StringUtils.isNotBlank(project.getProjectType())) {


### PR DESCRIPTION
Simple change to convert project name to lowercase both in search param as well as column value from DB to do a case insensitive compare. This has been tested in the works dev environment and is working well. Health can also benefit from this change.