### PR TITLE
Date difference fix

### DIFF
--- a/core-services/dashboard-analytics/src/main/java/com/tarento/analytics/helper/TargetPerDateComputeHelper.java
+++ b/core-services/dashboard-analytics/src/main/java/com/tarento/analytics/helper/TargetPerDateComputeHelper.java
@@ -44,7 +44,7 @@ public class TargetPerDateComputeHelper implements ComputeHelper {
 				}
 				logger.info("End Date after Round Off: " + String.valueOf(eDate));
 		        Long dateDifference = TimeUnit.DAYS.convert((eDate - sDate), TimeUnit.MILLISECONDS);
-		        if(dateDifference == 0l) dateDifference = dateDifference + 1l ;
+		        dateDifference = dateDifference + 1l ;
 
 				for(Data eachData : data) { 
 						Double value = (Double) eachData.getHeaderValue();

--- a/core-services/dashboard-analytics/src/main/java/com/tarento/analytics/helper/TargetPerDateComputeHelper.java
+++ b/core-services/dashboard-analytics/src/main/java/com/tarento/analytics/helper/TargetPerDateComputeHelper.java
@@ -43,8 +43,10 @@ public class TargetPerDateComputeHelper implements ComputeHelper {
 					eDate = eDate + ROUND_OFF; 
 				}
 				logger.info("End Date after Round Off: " + String.valueOf(eDate));
-		        Long dateDifference = TimeUnit.DAYS.convert((eDate - sDate), TimeUnit.MILLISECONDS);
-		        dateDifference = dateDifference + 1l ;
+		        long dateDifference = TimeUnit.DAYS.convert((eDate - sDate), TimeUnit.MILLISECONDS);
+				logger.info("eDate, sDate, datediff: " + eDate + "," + sDate + "," + dateDifference);
+		        dateDifference = dateDifference + 1L;
+				logger.info("dateDiff: " + dateDifference);
 
 				for(Data eachData : data) { 
 						Double value = (Double) eachData.getHeaderValue();

--- a/core-services/dashboard-analytics/src/main/java/com/tarento/analytics/helper/TargetPerDateComputeHelper.java
+++ b/core-services/dashboard-analytics/src/main/java/com/tarento/analytics/helper/TargetPerDateComputeHelper.java
@@ -43,8 +43,7 @@ public class TargetPerDateComputeHelper implements ComputeHelper {
 					eDate = eDate + ROUND_OFF; 
 				}
 				logger.info("End Date after Round Off: " + String.valueOf(eDate));
-		        long dateDifference = TimeUnit.DAYS.convert((eDate - sDate), TimeUnit.MILLISECONDS);
-		        dateDifference = dateDifference + 1L;
+		        Long dateDifference = TimeUnit.DAYS.convert((eDate - sDate), TimeUnit.MILLISECONDS) + 1L;
 
 				for(Data eachData : data) { 
 						Double value = (Double) eachData.getHeaderValue();
@@ -74,8 +73,7 @@ public class TargetPerDateComputeHelper implements ComputeHelper {
 					eDate = eDate + ROUND_OFF;
 				}
 				logger.info("End Date after Round Off: " + String.valueOf(eDate));
-				Long dateDifference = TimeUnit.DAYS.convert((eDate - sDate), TimeUnit.MILLISECONDS);
-				dateDifference = dateDifference + 1l ;
+				Long dateDifference = TimeUnit.DAYS.convert((eDate - sDate), TimeUnit.MILLISECONDS) + 1L;
 
 				for(Data eachData : data) {
 					Double value = (Double) eachData.getHeaderValue();
@@ -117,8 +115,7 @@ public class TargetPerDateComputeHelper implements ComputeHelper {
 					eDate = eDate + ROUND_OFF;
 				}
 				logger.info("End Date after Round Off: " + String.valueOf(eDate));
-				Long dateDifference = TimeUnit.DAYS.convert((eDate - sDate), TimeUnit.MILLISECONDS);
-				dateDifference = dateDifference + 1l ;
+				Long dateDifference = TimeUnit.DAYS.convert((eDate - sDate), TimeUnit.MILLISECONDS) + 1L;
 
 				value = (value / NUMBER_OF_DAYS) * dateDifference;
 				logger.info("Value is : " + value + " :: Date Difference is : " + dateDifference);
@@ -149,8 +146,7 @@ public class TargetPerDateComputeHelper implements ComputeHelper {
 					eDate = eDate + ROUND_OFF;
 				}
 				logger.info("End Date after Round Off: " + String.valueOf(eDate));
-				Long dateDifference = TimeUnit.DAYS.convert((eDate - sDate), TimeUnit.MILLISECONDS);
-				dateDifference = dateDifference + 1l ;
+				Long dateDifference = TimeUnit.DAYS.convert((eDate - sDate), TimeUnit.MILLISECONDS) + 1L;
 
 				value = (value / NUMBER_OF_DAYS) * dateDifference;
 

--- a/core-services/dashboard-analytics/src/main/java/com/tarento/analytics/helper/TargetPerDateComputeHelper.java
+++ b/core-services/dashboard-analytics/src/main/java/com/tarento/analytics/helper/TargetPerDateComputeHelper.java
@@ -44,9 +44,7 @@ public class TargetPerDateComputeHelper implements ComputeHelper {
 				}
 				logger.info("End Date after Round Off: " + String.valueOf(eDate));
 		        long dateDifference = TimeUnit.DAYS.convert((eDate - sDate), TimeUnit.MILLISECONDS);
-				logger.info("eDate, sDate, datediff: " + eDate + "," + sDate + "," + dateDifference);
 		        dateDifference = dateDifference + 1L;
-				logger.info("dateDiff: " + dateDifference);
 
 				for(Data eachData : data) { 
 						Double value = (Double) eachData.getHeaderValue();
@@ -77,7 +75,7 @@ public class TargetPerDateComputeHelper implements ComputeHelper {
 				}
 				logger.info("End Date after Round Off: " + String.valueOf(eDate));
 				Long dateDifference = TimeUnit.DAYS.convert((eDate - sDate), TimeUnit.MILLISECONDS);
-				if(dateDifference == 0l) dateDifference = dateDifference + 1l ;
+				dateDifference = dateDifference + 1l ;
 
 				for(Data eachData : data) {
 					Double value = (Double) eachData.getHeaderValue();
@@ -120,7 +118,7 @@ public class TargetPerDateComputeHelper implements ComputeHelper {
 				}
 				logger.info("End Date after Round Off: " + String.valueOf(eDate));
 				Long dateDifference = TimeUnit.DAYS.convert((eDate - sDate), TimeUnit.MILLISECONDS);
-				if(dateDifference == 0l) dateDifference = dateDifference + 1l ;
+				dateDifference = dateDifference + 1l ;
 
 				value = (value / NUMBER_OF_DAYS) * dateDifference;
 				logger.info("Value is : " + value + " :: Date Difference is : " + dateDifference);
@@ -152,7 +150,7 @@ public class TargetPerDateComputeHelper implements ComputeHelper {
 				}
 				logger.info("End Date after Round Off: " + String.valueOf(eDate));
 				Long dateDifference = TimeUnit.DAYS.convert((eDate - sDate), TimeUnit.MILLISECONDS);
-				if(dateDifference == 0l) dateDifference = dateDifference + 1l ;
+				dateDifference = dateDifference + 1l ;
 
 				value = (value / NUMBER_OF_DAYS) * dateDifference;
 


### PR DESCRIPTION
On Dashboard, right now, the difference of days, will only compute number of full days between starttime and endtime of the filters. If start date is 28th august 00:00 and end date is 29th august 11:59:59 PM (these are the values being sent as part of filters  in dashboard when we select 28th as start date and 29th as end date), the java library returns only one day as the difference. Hence we added 1 as a static value to this output, to get proper targets on the dashboard when selected 2 days in datepicker