### PR TITLE
Revert "HLM-6185: Added null check for the project task resources list"

### DIFF
--- a/health-services/transformer/src/main/java/org/egov/transformer/models/downstream/ProjectTaskIndexV1.java
+++ b/health-services/transformer/src/main/java/org/egov/transformer/models/downstream/ProjectTaskIndexV1.java
@@ -59,6 +59,4 @@ public class ProjectTaskIndexV1 {
     private Long lastModifiedTime;
     @JsonProperty("isDeleted")
     private boolean isDeleted;
-    @JsonProperty("status")
-    private String status;
 }

--- a/health-services/transformer/src/main/java/org/egov/transformer/service/ProjectService.java
+++ b/health-services/transformer/src/main/java/org/egov/transformer/service/ProjectService.java
@@ -235,36 +235,6 @@ public class ProjectService {
         return convertToProjectTypeList(response);
     }
 
-    /**
-     * Retrieves the beneficiary type for a given project ID and tenant ID.
-     *
-     * @param projectId The ID of the project.
-     * @param tenantId  The ID of the tenant.
-     * @return The beneficiary type as a String. If not found, returns an empty string.
-     */
-    public String getBeneficiaryType(String projectId, String tenantId) {
-        // Fetch the project details using the provided project ID and tenant ID
-        Project project = getProject(projectId, tenantId);
-
-        // Construct a JSONPath filter to locate the beneficiary type within the project details
-        String filter = "$[?(@.id == '" + project.getProjectTypeId() + "')].beneficiaryType";
-
-        // Create a RequestInfo object with user information for making the MDMS request
-        RequestInfo requestInfo = RequestInfo.builder()
-                .userInfo(User.builder().uuid("transformer-uuid").build())
-                .build();
-
-        // Fetch the MDMS response based on the constructed filter
-        JsonNode response = fetchMdmsResponse(requestInfo, tenantId, PROJECT_TYPES,
-                transformerProperties.getMdmsModule(), filter);
-
-        // Convert the MDMS response to a list of beneficiary types
-        List<String> beneficiaryTypeList = convertToProjectTypeList(response);
-
-        // Return the first beneficiary type if the list is not empty; otherwise, return an empty string
-        return !CollectionUtils.isEmpty(beneficiaryTypeList) ? beneficiaryTypeList.get(0) : "";
-    }
-
     private JsonNode fetchMdmsResponse(RequestInfo requestInfo, String tenantId, String name,
                                        String moduleName, String filter) {
         MdmsCriteriaReq serviceRegistry = getMdmsRequest(requestInfo, tenantId, name, moduleName, filter);

--- a/health-services/transformer/src/main/java/org/egov/transformer/service/ProjectTaskTransformationService.java
+++ b/health-services/transformer/src/main/java/org/egov/transformer/service/ProjectTaskTransformationService.java
@@ -9,13 +9,10 @@ import org.egov.common.producer.Producer;
 import org.egov.transformer.service.transformer.Transformer;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import org.springframework.util.CollectionUtils;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -78,74 +75,34 @@ public abstract class ProjectTaskTransformationService implements Transformation
             }
             log.info("boundary labels {}", boundaryLabelToNameMap.toString());
             Map<String, String> finalBoundaryLabelToNameMap = boundaryLabelToNameMap;
-            String beneficiaryType = projectService.getBeneficiaryType(task.getProjectId(), task.getTenantId());
-
-            List<ProjectTaskIndexV1> taskResourceIndex = null;
-            // Check if the task's resources list is not null and not empty
-            if(!CollectionUtils.isEmpty(task.getResources())) {
-                taskResourceIndex = task.getResources().stream().map(r ->
-                        ProjectTaskIndexV1.builder()
-                                .id(r.getId())
-                                .taskId(task.getId())
-                                .taskType("DELIVERY")
-                                .projectId(task.getProjectId())
-                                .startDate(task.getActualStartDate())
-                                .endDate(task.getActualEndDate())
-                                .productVariant(r.getProductVariantId())
-                                .isDelivered(r.getIsDelivered())
-                                .quantity(r.getQuantity())
-                                .status(task.getStatus())
-                                .deliveredTo(beneficiaryType)
-                                .deliveryComments(r.getDeliveryComment())
-                                .province(finalBoundaryLabelToNameMap != null ? finalBoundaryLabelToNameMap.get(properties.getProvince()) : null)
-                                .district(finalBoundaryLabelToNameMap != null ? finalBoundaryLabelToNameMap.get(properties.getDistrict()) : null)
-                                .administrativeProvince(finalBoundaryLabelToNameMap != null ?
-                                        finalBoundaryLabelToNameMap.get(properties.getAdministrativeProvince()) : null)
-                                .locality(finalBoundaryLabelToNameMap != null ? finalBoundaryLabelToNameMap.get(properties.getLocality()) : null)
-                                .village(finalBoundaryLabelToNameMap != null ? finalBoundaryLabelToNameMap.get(properties.getVillage()) : null)
-                                .latitude(task.getAddress().getLatitude())
-                                .longitude(task.getAddress().getLongitude())
-                                .createdTime(task.getAuditDetails().getCreatedTime())
-                                .createdBy(task.getAuditDetails().getCreatedBy())
-                                .lastModifiedTime(task.getAuditDetails().getLastModifiedTime())
-                                .lastModifiedBy(task.getAuditDetails().getLastModifiedBy())
-                                .isDeleted(task.getIsDeleted())
-                                .build()
-                ).collect(Collectors.toList());
-            } else {
-                taskResourceIndex = new ArrayList<>();
-                taskResourceIndex.add(
-                        ProjectTaskIndexV1.builder()
-                                .id(UUID.randomUUID().toString())
-                                .taskId(task.getId())
-                                .taskType("DELIVERY")
-                                .projectId(task.getProjectId())
-                                .startDate(task.getActualStartDate())
-                                .endDate(task.getActualEndDate())
-                                .productVariant(null)
-                                .isDelivered(false)
-                                .status(task.getStatus())
-                                .quantity(null)
-                                .deliveredTo(beneficiaryType)
-                                .deliveryComments(null)
-                                .province(finalBoundaryLabelToNameMap != null ? finalBoundaryLabelToNameMap.get(properties.getProvince()) : null)
-                                .district(finalBoundaryLabelToNameMap != null ? finalBoundaryLabelToNameMap.get(properties.getDistrict()) : null)
-                                .administrativeProvince(finalBoundaryLabelToNameMap != null ?
-                                        finalBoundaryLabelToNameMap.get(properties.getAdministrativeProvince()) : null)
-                                .locality(finalBoundaryLabelToNameMap != null ? finalBoundaryLabelToNameMap.get(properties.getLocality()) : null)
-                                .village(finalBoundaryLabelToNameMap != null ? finalBoundaryLabelToNameMap.get(properties.getVillage()) : null)
-                                .latitude(task.getAddress().getLatitude())
-                                .longitude(task.getAddress().getLongitude())
-                                .createdTime(task.getAuditDetails().getCreatedTime())
-                                .createdBy(task.getAuditDetails().getCreatedBy())
-                                .lastModifiedTime(task.getAuditDetails().getLastModifiedTime())
-                                .lastModifiedBy(task.getAuditDetails().getLastModifiedBy())
-                                .isDeleted(task.getIsDeleted())
-                                .build()
-                );
-            }
-
-            return taskResourceIndex;
+            return task.getResources().stream().map(r ->
+                    ProjectTaskIndexV1.builder()
+                            .id(r.getId())
+                            .taskId(task.getId())
+                            .taskType("DELIVERY")
+                            .projectId(task.getProjectId())
+                            .startDate(task.getActualStartDate())
+                            .endDate(task.getActualEndDate())
+                            .productVariant(r.getProductVariantId())
+                            .isDelivered(r.getIsDelivered())
+                            .quantity(r.getQuantity())
+                            .deliveredTo("HOUSEHOLD")
+                            .deliveryComments(r.getDeliveryComment())
+                            .province(finalBoundaryLabelToNameMap != null ? finalBoundaryLabelToNameMap.get(properties.getProvince()) : null)
+                            .district(finalBoundaryLabelToNameMap != null ? finalBoundaryLabelToNameMap.get(properties.getDistrict()) : null)
+                            .administrativeProvince(finalBoundaryLabelToNameMap != null ?
+                                    finalBoundaryLabelToNameMap.get(properties.getAdministrativeProvince()) : null)
+                            .locality(finalBoundaryLabelToNameMap != null ? finalBoundaryLabelToNameMap.get(properties.getLocality()) : null)
+                            .village(finalBoundaryLabelToNameMap != null ? finalBoundaryLabelToNameMap.get(properties.getVillage()) : null)
+                            .latitude(task.getAddress().getLatitude())
+                            .longitude(task.getAddress().getLongitude())
+                            .createdTime(task.getAuditDetails().getCreatedTime())
+                            .createdBy(task.getAuditDetails().getCreatedBy())
+                            .lastModifiedTime(task.getAuditDetails().getLastModifiedTime())
+                            .lastModifiedBy(task.getAuditDetails().getLastModifiedBy())
+                            .isDeleted(task.getIsDeleted())
+                            .build()
+            ).collect(Collectors.toList());
         }
     }
 }


### PR DESCRIPTION
Reverts egovernments/health-campaign-services#767

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed the `status` field from project task indexing to streamline data handling.
  - Simplified the task transformation process by removing unnecessary code and directly mapping task resources.
  - Removed the `getBeneficiaryType` method from the project service to reduce code complexity and improve maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->