### PR TITLE
updated generate different tab logic if there is no different tab then it will show previous filestore id

### DIFF
--- a/health-services/project-factory/src/server/utils/campaignUtils.ts
+++ b/health-services/project-factory/src/server/utils/campaignUtils.ts
@@ -1775,7 +1775,7 @@ async function getFinalValidHeadersForTargetSheetAsPerCampaignType(request: any,
 }
 
 async function getDifferentTabGeneratedBasedOnConfig(request: any, boundaryDataGeneratedBeforeDifferentTabSeparation: any, localizationMap?: any) {
-    var boundaryDataGeneratedAfterDifferentTabSeparation: any;
+    var boundaryDataGeneratedAfterDifferentTabSeparation: any = boundaryDataGeneratedBeforeDifferentTabSeparation;
     const boundaryData = await getBoundaryDataAfterGeneration(boundaryDataGeneratedBeforeDifferentTabSeparation, request, localizationMap);
     const differentTabsBasedOnLevel = getLocalizedName(config?.boundary?.generateDifferentTabsOnBasisOf, localizationMap);
     logger.info(`Boundaries are seperated based on hierarchy type ${differentTabsBasedOnLevel}`)

--- a/health-services/project-factory/src/server/utils/campaignUtils.ts
+++ b/health-services/project-factory/src/server/utils/campaignUtils.ts
@@ -1775,6 +1775,7 @@ async function getFinalValidHeadersForTargetSheetAsPerCampaignType(request: any,
 }
 
 async function getDifferentTabGeneratedBasedOnConfig(request: any, boundaryDataGeneratedBeforeDifferentTabSeparation: any, localizationMap?: any) {
+    // assigning fileStoreId of a single district tab if criteria for multiple tabs are not met
     var boundaryDataGeneratedAfterDifferentTabSeparation: any = boundaryDataGeneratedBeforeDifferentTabSeparation;
     const boundaryData = await getBoundaryDataAfterGeneration(boundaryDataGeneratedBeforeDifferentTabSeparation, request, localizationMap);
     const differentTabsBasedOnLevel = getLocalizedName(config?.boundary?.generateDifferentTabsOnBasisOf, localizationMap);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved data consistency in the `getDifferentTabGeneratedBasedOnConfig` function by ensuring initialization of `boundaryDataGeneratedAfterDifferentTabSeparation` to a passed parameter value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->