### PR TITLE
Removing validateResources method from PlanValidator

### DIFF
--- a/health-services/plan-service/src/main/java/digit/service/PlanValidator.java
+++ b/health-services/plan-service/src/main/java/digit/service/PlanValidator.java
@@ -82,6 +82,9 @@ public class PlanValidator {
         // Validate plan configuration existence
         validatePlanConfigurationExistence(request);
 
+        // Validate resources
+        validateResources(request);
+
         // Validate resource-activity linkage
         validateResourceActivityLinkage(request);
 
@@ -227,6 +230,19 @@ public class PlanValidator {
     }
 
     /**
+     * This method validates the resources provided in the request
+     *
+     * @param request
+     */
+    private void validateResources(PlanRequest request) {
+        // If plan configuration id is not provided, providing resources is mandatory
+        if (ObjectUtils.isEmpty(request.getPlan().getPlanConfigurationId())
+                && CollectionUtils.isEmpty(request.getPlan().getResources())) {
+            throw new CustomException(PLAN_RESOURCES_MANDATORY_CODE, PLAN_RESOURCES_MANDATORY_MESSAGE);
+        }
+    }
+
+    /**
      * This method validates the linkage between resources and activities
      *
      * @param request
@@ -291,6 +307,9 @@ public class PlanValidator {
 
         // Validate plan configuration existence
         validatePlanConfigurationExistence(request);
+
+        // Validate resources
+        validateResources(request);
 
         // Validate resource uuid uniqueness
         validateResourceUuidUniqueness(request);

--- a/health-services/plan-service/src/main/java/digit/service/PlanValidator.java
+++ b/health-services/plan-service/src/main/java/digit/service/PlanValidator.java
@@ -82,9 +82,6 @@ public class PlanValidator {
         // Validate plan configuration existence
         validatePlanConfigurationExistence(request);
 
-        // Validate resources
-        validateResources(request);
-
         // Validate resource-activity linkage
         validateResourceActivityLinkage(request);
 
@@ -230,32 +227,6 @@ public class PlanValidator {
     }
 
     /**
-     * This method validates the resources provided in the request
-     *
-     * @param request
-     */
-    private void validateResources(PlanRequest request) {
-        // If plan configuration id is not provided, providing resources is mandatory
-        if (ObjectUtils.isEmpty(request.getPlan().getPlanConfigurationId())
-                && CollectionUtils.isEmpty(request.getPlan().getResources())) {
-            throw new CustomException(PLAN_RESOURCES_MANDATORY_CODE, PLAN_RESOURCES_MANDATORY_MESSAGE);
-        }
-
-        // If plan configuration id is provided, providing resources is not allowed
-        if (!ObjectUtils.isEmpty(request.getPlan().getPlanConfigurationId())
-                && !CollectionUtils.isEmpty(request.getPlan().getResources())) {
-            throw new CustomException(PLAN_RESOURCES_NOT_ALLOWED_CODE, PLAN_RESOURCES_NOT_ALLOWED_MESSAGE);
-        }
-
-        // Validate resource type existence
-        if (!CollectionUtils.isEmpty(request.getPlan().getResources())) {
-            request.getPlan().getResources().forEach(resource -> {
-                // Validate resource type existence
-            });
-        }
-    }
-
-    /**
      * This method validates the linkage between resources and activities
      *
      * @param request
@@ -320,9 +291,6 @@ public class PlanValidator {
 
         // Validate plan configuration existence
         validatePlanConfigurationExistence(request);
-
-        // Validate resources
-        validateResources(request);
 
         // Validate resource uuid uniqueness
         validateResourceUuidUniqueness(request);

--- a/health-services/plan-service/src/main/java/digit/service/PlanValidator.java
+++ b/health-services/plan-service/src/main/java/digit/service/PlanValidator.java
@@ -382,11 +382,14 @@ public class PlanValidator {
      */
     private void validatePlanExistence(PlanRequest request) {
         // If plan id provided is invalid, throw an exception
-        if (CollectionUtils.isEmpty(planRepository.search(PlanSearchCriteria.builder()
+        List<Plan> planFromDatabase = planRepository.search(PlanSearchCriteria.builder()
                 .ids(Collections.singleton(request.getPlan().getId()))
-                .build()))) {
+                .build());
+        if (CollectionUtils.isEmpty(planFromDatabase)) {
             throw new CustomException(INVALID_PLAN_ID_CODE, INVALID_PLAN_ID_MESSAGE);
         }
+        // enriching boundary ancestral path for incoming plan request from the database
+        request.getPlan().setBoundaryAncestralPath(planFromDatabase.get(0).getBoundaryAncestralPath());
     }
 
     /**


### PR DESCRIPTION
1. Removing validateResources method from PlanValidator
2. Enriching boundaryAncestralPath on Plan update