### PR TITLE
HCMPRE:2261- Increasing the kafka producer message size for update-plan-facility topic

### DIFF
--- a/health-services/census-service/src/main/resources/application.properties
+++ b/health-services/census-service/src/main/resources/application.properties
@@ -30,6 +30,9 @@ spring.kafka.producer.value-serializer=org.springframework.kafka.support.seriali
 spring.kafka.listener.missing-topics-fatal=false
 spring.kafka.consumer.properties.spring.json.use.type.headers=false
 spring.kafka.producer.properties.max.request.size=3000000
+spring.kafka.consumer.properties.fetch.max.bytes=4000000
+spring.kafka.consumer.properties.max.partition.fetch.bytes=4000000
+
 
 # KAFKA CONSUMER CONFIGURATIONS
 kafka.consumer.config.auto_commit=true

--- a/health-services/plan-service/src/main/resources/application.properties
+++ b/health-services/plan-service/src/main/resources/application.properties
@@ -31,6 +31,7 @@ spring.kafka.producer.value-serializer=org.springframework.kafka.support.seriali
 spring.kafka.listener.missing-topics-fatal=false
 spring.kafka.consumer.properties.spring.json.use.type.headers=false
 spring.kafka.producer.properties.max.request.size=3000000
+spring.kafka.producer.properties.update-plan-facility.max.request.size=4000000
 
 # KAFKA CONSUMER CONFIGURATIONS
 kafka.consumer.config.auto_commit=true


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Enhanced messaging performance by increasing the maximum allowed request size for specific facility update operations.
	- Improved Kafka consumer settings by allowing larger data fetch sizes for better performance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->