### PR TITLE
HCMPRE-2365: Removing exact match assignee search criteria from PlanQueryBuilder

### DIFF
--- a/health-services/plan-service/src/main/java/digit/repository/querybuilder/PlanQueryBuilder.java
+++ b/health-services/plan-service/src/main/java/digit/repository/querybuilder/PlanQueryBuilder.java
@@ -151,12 +151,6 @@ public class PlanQueryBuilder {
 
         if (!ObjectUtils.isEmpty(planSearchCriteria.getAssignee())) {
             queryUtil.addClauseIfRequired(builder, preparedStmtList);
-            builder.append(" assignee = ? ");
-            preparedStmtList.add(planSearchCriteria.getAssignee());
-        }
-
-        if (!ObjectUtils.isEmpty(planSearchCriteria.getAssignee())) {
-            queryUtil.addClauseIfRequired(builder, preparedStmtList);
             builder.append(" ARRAY [ ").append(queryUtil.createQuery(Collections.singleton(planSearchCriteria.getAssignee()).size())).append(" ]").append("::text[] ");
             builder.append(" && string_to_array(assignee, ',') ");
             queryUtil.addToPreparedStatement(preparedStmtList, Collections.singleton(planSearchCriteria.getAssignee()));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the plan search filtering mechanism for assignment criteria to use a more flexible matching approach. This change may lead to more accurate results when filtering plans, providing users with improved search reliability without altering public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->