### PR TITLE
HDDF-2933: Bauchi stock search model update

### DIFF
--- a/health-services/libraries/health-services-models/pom.xml
+++ b/health-services/libraries/health-services-models/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.egov.common</groupId>
     <artifactId>health-services-models</artifactId>
-    <version>1.0.25-SNAPSHOT</version>
+    <version>1.0.26-SNAPSHOT</version>
     <properties>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>

--- a/health-services/libraries/health-services-models/pom.xml
+++ b/health-services/libraries/health-services-models/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.egov.common</groupId>
     <artifactId>health-services-models</artifactId>
-    <version>1.0.26-SNAPSHOT</version>
+    <version>1.0.25-bauchi-impl</version>
     <properties>
         <java.version>17</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>

--- a/health-services/libraries/health-services-models/src/main/java/org/egov/common/models/stock/StockSearch.java
+++ b/health-services/libraries/health-services-models/src/main/java/org/egov/common/models/stock/StockSearch.java
@@ -57,5 +57,11 @@ public class StockSearch extends EgovOfflineSearchModel {
 
     @JsonProperty("transactingPartyType")
     private String transactingPartyType = null;
+
+    @JsonProperty("receiverId")
+    private List<String> receiverId = null;
+
+    @JsonProperty("senderId")
+    private List<String> senderId = null;
 }
 

--- a/health-services/libraries/health-services-models/src/main/java/org/egov/common/models/stock/StockSearch.java
+++ b/health-services/libraries/health-services-models/src/main/java/org/egov/common/models/stock/StockSearch.java
@@ -61,7 +61,8 @@ public class StockSearch extends EgovOfflineSearchModel {
     @JsonProperty("receiverId")
     private List<String> receiverId = null;
 
-    @JsonProperty("senderId")
-    private List<String> senderId = null;
+    @JsonProperty("receiverType")
+    private SenderReceiverType receiverType;
+
 }
 

--- a/health-services/stock/pom.xml
+++ b/health-services/stock/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.egov.common</groupId>
             <artifactId>health-services-models</artifactId>
-            <version>1.0.23-dev-SNAPSHOT</version>
+            <version>1.0.25-bauchi-impl</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
### Problem:
 
For the Bauchi campaign, we need to downsync the stock transaction for the receiver.
Ref: [PRD doc](https://docs.google.com/document/d/1O_ZmH4BnKuWwRn5WUH7ujSXyYqtngxvIznXj3GeDpaM/edit?tab=t.alqxq6eyu4py)
 
### Solution:
 
For this, we have proposed the addition of `receiverIds` and `receiverType` in the Stock Search model to allow for searching stocks for the logged-in user or their facility. 
Ref: [solution doc](https://docs.google.com/document/d/1P2N5_QONY8YZIPkqsKhW28J7cRq5zTQTmrwoyGdodGc/edit?tab=t.0#heading=h.t1wjc92d24a9)