### PR TITLE
Broker fix

### DIFF
--- a/health-services/project-factory/src/server/config/generationtTemplateConfigs.ts
+++ b/health-services/project-factory/src/server/config/generationtTemplateConfigs.ts
@@ -18,7 +18,7 @@ export const generationtTemplateConfigs : any = {
             {
                 sheetName: "HCM_ADMIN_CONSOLE_BOUNDARY_DATA",
                 schemaName: "boundary-data",
-                lockWholeSheet: true
+                lockWholeSheet: false
             }
         ],
     },
@@ -45,7 +45,7 @@ export const generationtTemplateConfigs : any = {
             {
                 sheetName: "HCM_ADMIN_CONSOLE_BOUNDARY_DATA",
                 schemaName: "boundary-data",
-                lockWholeSheet: true
+                lockWholeSheet: false
             }
         ],
     },

--- a/health-services/project-factory/src/server/config/index.ts
+++ b/health-services/project-factory/src/server/config/index.ts
@@ -21,7 +21,7 @@ const config = {
   excludeBoundaryNameAtLastFromBoundaryCodes: (process.env.EXCLUDE_BOUNDARY_NAME_AT_LAST_FROM_BOUNDARY_CODES === "true") || false,
   isEnvironmentCentralInstance: process.env.IS_ENVIRONMENT_CENTRAL_INSTANCE === "true",
   masterNameForSplitBoundariesOn: "HierarchySchema",
-  basesecret: process.env.BASE_SECRET || 'egov-admin-console-enc',
+  basesecret: process.env.BASE_SECRET,
   boundary: {
     boundaryCode: process.env.BOUNDARY_CODE_HEADER_NAME || "HCM_ADMIN_CONSOLE_BOUNDARY_CODE",
     boundaryCodeMandatory: 'HCM_ADMIN_CONSOLE_BOUNDARY_CODE_MANDATORY',

--- a/health-services/project-factory/src/server/config/index.ts
+++ b/health-services/project-factory/src/server/config/index.ts
@@ -21,7 +21,7 @@ const config = {
   excludeBoundaryNameAtLastFromBoundaryCodes: (process.env.EXCLUDE_BOUNDARY_NAME_AT_LAST_FROM_BOUNDARY_CODES === "true") || false,
   isEnvironmentCentralInstance: process.env.IS_ENVIRONMENT_CENTRAL_INSTANCE === "true",
   masterNameForSplitBoundariesOn: "HierarchySchema",
-  basesecret: process.env.BASE_SECRET,
+  basesecret: process.env.BASE_SECRET || 'egov-admin-console-enc',
   boundary: {
     boundaryCode: process.env.BOUNDARY_CODE_HEADER_NAME || "HCM_ADMIN_CONSOLE_BOUNDARY_CODE",
     boundaryCodeMandatory: 'HCM_ADMIN_CONSOLE_BOUNDARY_CODE_MANDATORY',

--- a/health-services/project-factory/src/server/config/index.ts
+++ b/health-services/project-factory/src/server/config/index.ts
@@ -197,13 +197,13 @@ const config = {
     validateCampaignIdInMetadata: process.env.VALIDATE_CAMPAIGN_ID_IN_METADATA === "true"
   },
   resourceCreationConfig: {
-  maxAttemptsForResourceCreationOrMapping: Number(process.env.MAX_RESOURCE_CREATION_ATTEMPTS || 200),
-  // wait time between each polling attempt in milliseconds (default: 60 sec)
-  waitTimeOfEachAttemptOfResourceCreationOrMappping: Number(process.env.WAIT_TIME_OF_EACH_ATTEMPT_MS || 40000),
+    maxAttemptsForResourceCreationOrMapping: Number(process.env.MAX_RESOURCE_CREATION_ATTEMPTS || 200),
+    // wait time between each polling attempt in milliseconds (default: 60 sec)
+    waitTimeOfEachAttemptOfResourceCreationOrMappping: Number(process.env.WAIT_TIME_OF_EACH_ATTEMPT_MS || 40000),
   }
 };
 
-if(!config.basesecret){
+if (!config.basesecret) {
   throw new Error('BASE_SECRET is undefined. Please set "BASE_SECRET" in env.');
 }
 

--- a/health-services/project-factory/src/server/kafka/Listener.ts
+++ b/health-services/project-factory/src/server/kafka/Listener.ts
@@ -8,7 +8,7 @@ import { handleTaskForCampaign } from '../utils/taskUtils';
 
 const kafka = new Kafka({
     clientId: 'project-factory-consumer',
-    brokers: [config?.host?.KAFKA_BROKER_HOST],
+    brokers: config?.host?.KAFKA_BROKER_HOST?.split(',').map(b => b.trim()),
     logLevel: logLevel.NOTHING,
 });
 

--- a/health-services/project-factory/src/server/kafka/Producer.ts
+++ b/health-services/project-factory/src/server/kafka/Producer.ts
@@ -15,7 +15,7 @@ const createKafkaClientAndProducer = async () => {
             maxRetryTime: 30000
         },
         clientId: 'project-factory-producer',
-        brokers: [config?.host?.KAFKA_BROKER_HOST],
+        brokers: config?.host?.KAFKA_BROKER_HOST?.split(',').map(b => b.trim()),
         logLevel: logLevel.INFO,
         logCreator: (level) => (log: LogEntry) => {
             if (log.namespace === 'kafka.network' && log.log.message && log.log.message.includes('retry')) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for specifying multiple Kafka brokers via a single comma-separated environment variable for both consumer and producer (single-host remains supported).

* **Bug Fix / Behavior Change**
  * Two template sheet entries (HCM_ADMIN_CONSOLE_BOUNDARY_DATA) changed to not lock the whole sheet, altering sheet-lock behavior for user and facility modules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->