### PR TITLE
Plan service additional details fix

### DIFF
--- a/health-services/resource-generator/src/main/java/org/egov/processor/util/ParsingUtil.java
+++ b/health-services/resource-generator/src/main/java/org/egov/processor/util/ParsingUtil.java
@@ -425,7 +425,7 @@ public class ParsingUtil {
                     return returnType.cast(node.asBoolean());
                 } else if (returnType == String.class && node.isTextual()) {
                     return returnType.cast(node.asText());
-                }else if (returnType == Object.class && node.isObject()) {
+                } else if (returnType == Object.class && node.isObject()) {
                     return returnType.cast(objectMapper.convertValue(node, Map.class));
                 }
             }

--- a/health-services/resource-generator/src/main/java/org/egov/processor/util/ParsingUtil.java
+++ b/health-services/resource-generator/src/main/java/org/egov/processor/util/ParsingUtil.java
@@ -425,7 +425,11 @@ public class ParsingUtil {
                     return returnType.cast(node.asBoolean());
                 } else if (returnType == String.class && node.isTextual()) {
                     return returnType.cast(node.asText());
+                }else if (returnType == Object.class && node.isObject()) {
+                    return returnType.cast(objectMapper.convertValue(node, Map.class));
                 }
+
+
             }
             return null;
         } catch (Exception e) {

--- a/health-services/resource-generator/src/main/java/org/egov/processor/util/ParsingUtil.java
+++ b/health-services/resource-generator/src/main/java/org/egov/processor/util/ParsingUtil.java
@@ -428,8 +428,6 @@ public class ParsingUtil {
                 }else if (returnType == Object.class && node.isObject()) {
                     return returnType.cast(objectMapper.convertValue(node, Map.class));
                 }
-
-
             }
             return null;
         } catch (Exception e) {


### PR DESCRIPTION
Census service additional details should be copied to plan.
The parsing util didn't handle case for Object.class

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Returns JSON object fields as key–value maps when a generic/object type is requested, exposing nested structures.
  * Extends handling to full JSON objects while preserving behavior for numbers, booleans, and strings.
  * Improves compatibility with diverse JSON payloads in resource generation, reducing need for downstream custom parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->