### PR TITLE
Added docker file changes related to vapt docker file changes

### DIFF
--- a/build/maven-java17/Dockerfile
+++ b/build/maven-java17/Dockerfile
@@ -1,27 +1,21 @@
-FROM maven:3.9.6-amazoncorretto-17 AS build
+# ──────────────── BUILD STAGE ────────────────
+FROM maven:3.9-eclipse-temurin-17 AS build
 ARG WORK_DIR
 WORKDIR /app
 
 # Copy project files
 COPY ${WORK_DIR}/pom.xml ./pom.xml
-COPY build/maven/start.sh ./start.sh
 COPY ${WORK_DIR}/src ./src
 
 # Build the project
-RUN mvn -B -f /app/pom.xml package
+RUN mvn -B -f /app/pom.xml package -DskipTests
 
-# Runtime image – using a multi-arch base image
-FROM amazoncorretto:17-alpine
+# ─────────────── RUNTIME STAGE ───────────────
+FROM gcr.io/distroless/java17-debian12:nonroot
 
 WORKDIR /opt/egov
 
-# Copy artifacts from the build stage
-COPY --from=build /app/target/*.jar /app/start.sh /opt/egov/
+# Copy artifact from the build stage
+COPY --from=build /app/target/*.jar ./application.jar
 
-# Ensure the start script has correct line endings and is executable
-RUN dos2unix /opt/egov/start.sh && chmod +x /opt/egov/start.sh
-
-# Verify architecture inside the container
-RUN uname -m
-
-CMD ["/opt/egov/start.sh"]
+ENTRYPOINT ["java", "-jar", "application.jar"]

--- a/build/maven-java17/Dockerfile
+++ b/build/maven-java17/Dockerfile
@@ -8,7 +8,7 @@ COPY ${WORK_DIR}/pom.xml ./pom.xml
 COPY ${WORK_DIR}/src ./src
 
 # Build the project
-RUN mvn -B -f /app/pom.xml package -DskipTests
+RUN mvn -B -f /app/pom.xml package
 
 # ─────────────── RUNTIME STAGE ───────────────
 FROM gcr.io/distroless/java17-debian12:nonroot

--- a/build/maven/Dockerfile
+++ b/build/maven/Dockerfile
@@ -1,5 +1,5 @@
 # ──────────────── BUILD STAGE ────────────────
-FROM maven:3.9.6-amazoncorretto-8-debian AS build
+FROM maven:3.9-eclipse-temurin-8 AS build
 ARG WORK_DIR
 WORKDIR /app
 
@@ -8,11 +8,12 @@ COPY ${WORK_DIR}/pom.xml       ./pom.xml
 COPY build/maven/start.sh ./start.sh
 COPY ${WORK_DIR}/src           ./src
 
-RUN mvn -B -f pom.xml package
+# Build the app (skip tests for speed)
+RUN mvn -B -f pom.xml package -DskipTests
 
 
 # ─────────────── RUNTIME STAGE ───────────────
-FROM openjdk:8-jdk-alpine AS runtime
+FROM eclipse-temurin:8-jre AS runtime
 WORKDIR /opt/egov
 
 # Pull in the fat JAR and our startup script
@@ -21,5 +22,4 @@ COPY --from=build /app/start.sh    ./start.sh
 
 RUN chmod +x ./start.sh
 
-# Override any Alpine tini entrypoint and launch via shell
 ENTRYPOINT ["sh", "./start.sh"]

--- a/build/maven/Dockerfile
+++ b/build/maven/Dockerfile
@@ -9,7 +9,7 @@ COPY build/maven/start.sh ./start.sh
 COPY ${WORK_DIR}/src           ./src
 
 # Build the app (skip tests for speed)
-RUN mvn -B -f pom.xml package -DskipTests
+RUN mvn -B -f pom.xml package
 
 
 # ─────────────── RUNTIME STAGE ───────────────


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched to reproducible two-stage builds and updated build/runtime base images for Java 17 and Java 8.
  * Java 17 runtime simplified to a minimal distroless image and no longer relies on a startup script or architecture checks.
  * Java 8 build/runtime updated to newer Eclipse Temurin images with streamlined packaging and startup handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/egovernments/health-campaign-services/pull/1966?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->