### PR TITLE
fix: skip MDMS tenants missing districtCode/ddrName and log root cause

### DIFF
--- a/core-services/dashboard-analytics/src/main/java/com/tarento/analytics/org/service/MdmsApiMappings.java
+++ b/core-services/dashboard-analytics/src/main/java/com/tarento/analytics/org/service/MdmsApiMappings.java
@@ -100,6 +100,12 @@ public class MdmsApiMappings {
                 JsonNode ddrCode = tenant.findValue(Constants.MDMSKeys.DISTRICT_CODE);
                 JsonNode ddrName = tenant.findValue(Constants.MDMSKeys.DDR_NAME);
 
+                if (ddrCode == null || ddrName == null) {
+                    logger.warn("Skipping tenant {} - missing districtCode/ddrName in MDMS entry",
+                            tenantId != null ? tenantId.asText() : "<no code>");
+                    continue;
+                }
+
                 //JsonNode name = tenant.findValue(NAME);
                 //if(!codeValues.containsKey(tenantId.asText())) codeValues.put(tenantId.asText(), name.asText());
                 String cityName = ulbCityNamesMappings.get(tenantId.asText());
@@ -133,6 +139,7 @@ public class MdmsApiMappings {
 
             }
         } catch (Exception e){
+            logger.error("Failed to fetch DDR's from mdms", e);
             throw new CustomException("MDMS_ERROR","Failed to fetch DDR's from mdms");
         }
         ddrValueMap.entrySet().removeIf(map -> map.getValue().size()==0);


### PR DESCRIPTION
service startup was failing when any tenant in the MDMS tenant list
  lacked districtCode or ddrName (e.g. tenants without a city block),
  because findValue(...).asText() NPE'd and was rethrown as a generic
  "Failed to fetch DDR's from mdms" with no stack trace. Guard the loop
  to skip incomplete entries with a warning, and log the exception cause
  before wrapping so future failures are diagnosable.