### PR TITLE
Project Bulk create, dedupe boundary search in getBoundaryForValidation

### DIFF
--- a/health-services/project/src/main/java/org/egov/project/util/BoundaryV2Util.java
+++ b/health-services/project/src/main/java/org/egov/project/util/BoundaryV2Util.java
@@ -44,8 +44,9 @@ public class BoundaryV2Util {
      */
     public void validateBoundaryDetails(Map<String, List<String>> boundaryTypeBoundariesMap, String tenantId,
                                         RequestInfo requestInfo, String hierarchyTypeCode) {
-        // Flatten the lists of boundary codes from the map values
+        // Flatten and dedupe boundary codes (Boundary Service expects one value per unique code).
         List<String> boundaries = boundaryTypeBoundariesMap.values().stream().flatMap(List::stream)
+                .distinct()
                 .collect(Collectors.toList());
         if(CollectionUtils.isEmpty(boundaries)) return;
         try {

--- a/health-services/project/src/main/java/org/egov/project/util/BoundaryV2Util.java
+++ b/health-services/project/src/main/java/org/egov/project/util/BoundaryV2Util.java
@@ -65,10 +65,12 @@ public class BoundaryV2Util {
 
             // Extract invalid boundary codes
             List<String> invalidBoundaryCodes = new ArrayList<>(boundaries);
-            invalidBoundaryCodes.removeAll(boundarySearchResponse.getBoundary().stream()
-                    .map(Boundary::getCode)
-                    .collect(Collectors.toList())
-            );
+            if (!CollectionUtils.isEmpty(boundarySearchResponse.getBoundary())) {
+                invalidBoundaryCodes.removeAll(boundarySearchResponse.getBoundary().stream()
+                        .map(Boundary::getCode)
+                        .collect(Collectors.toList())
+                );
+            }
 
             // Throw exception if invalid boundary codes are found
             if (!invalidBoundaryCodes.isEmpty()) {

--- a/health-services/project/src/main/java/org/egov/project/validator/project/ProjectValidator.java
+++ b/health-services/project/src/main/java/org/egov/project/validator/project/ProjectValidator.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -439,27 +440,20 @@ public class ProjectValidator {
         log.info("Request data validated with MDMS");
     }
 
-    /* Returns boundaries map for all Projects in request body with key boundaryType and value as list of all boundaries corresponding to boundaryType*/
+    /* Returns map of boundaryType to its unique boundary codes for all Projects in request body. Duplicates across projects are dropped. */
     private Map<String, List<String>> getBoundaryForValidation(List<Project> projects) {
-        Map<String, List<String>> boundariesMap = new HashMap<>();
+        Map<String, Set<String>> boundariesMap = new HashMap<>();
         for (Project project: projects) {
             if (project.getAddress() != null && StringUtils.isNotBlank(project.getAddress().getBoundary())) {
                 String boundaryType = project.getAddress().getBoundaryType();
                 String boundary = project.getAddress().getBoundary();
-
-                // If the boundary type already exists in the map, add the boundary to the existing list
-                if (boundariesMap.containsKey(boundaryType)) {
-                    boundariesMap.get(boundaryType).add(boundary);
-                }
-                // If the boundary type does not exist in the map, create a new list and add the boundary to it
-                else {
-                    List<String> boundaries = new ArrayList<>();
-                    boundaries.add(boundary);
-                    boundariesMap.put(boundaryType, boundaries);
-                }
+                boundariesMap.computeIfAbsent(boundaryType, k -> new LinkedHashSet<>()).add(boundary);
             }
         }
-        return boundariesMap;
+
+        Map<String, List<String>> result = new HashMap<>();
+        boundariesMap.forEach((boundaryType, boundaries) -> result.put(boundaryType, new ArrayList<>(boundaries)));
+        return result;
     }
 
     /* Validates Boundary data with location service */

--- a/health-services/project/src/test/java/org/egov/project/util/BoundaryV2UtilTest.java
+++ b/health-services/project/src/test/java/org/egov/project/util/BoundaryV2UtilTest.java
@@ -1,0 +1,81 @@
+package org.egov.project.util;
+
+import org.egov.common.contract.request.RequestInfo;
+import org.egov.common.http.client.ServiceRequestClient;
+import org.egov.common.models.core.Boundary;
+import org.egov.project.web.models.boundary.BoundaryResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class BoundaryV2UtilTest {
+
+    @InjectMocks
+    private BoundaryV2Util boundaryV2Util;
+
+    @Mock
+    private ServiceRequestClient serviceRequestClient;
+
+    private BoundaryResponse boundaryResponse(String... codes) {
+        BoundaryResponse response = new BoundaryResponse();
+        for (String code : codes) {
+            response.addBoundaryItem(Boundary.builder().code(code).build());
+        }
+        return response;
+    }
+
+    @Test
+    @DisplayName("Should deduplicate boundary codes in the search URL when multiple projects share a boundary")
+    void shouldDeduplicateBoundaryCodesInSearchUrl() {
+        ReflectionTestUtils.setField(boundaryV2Util, "boundaryHost", "http://boundary");
+        ReflectionTestUtils.setField(boundaryV2Util, "boundarySearchUrl", "/boundary-service/boundary/_search");
+
+        // Two projects share the same boundary "mz"
+        Map<String, List<String>> boundaries = Collections.singletonMap("Country", Arrays.asList("mz", "mz"));
+
+        ArgumentCaptor<StringBuilder> uriCaptor = ArgumentCaptor.forClass(StringBuilder.class);
+        when(serviceRequestClient.fetchResult(uriCaptor.capture(), any(), eq(BoundaryResponse.class)))
+                .thenReturn(boundaryResponse("mz"));
+
+        boundaryV2Util.validateBoundaryDetails(boundaries, "mz", RequestInfo.builder().build(), "ADMIN");
+
+        String uri = uriCaptor.getValue().toString();
+        // Duplicate "mz" must collapse to a single code, and limit must reflect the unique count
+        assertTrue(uri.contains("codes=mz"), "URL should contain the boundary code");
+        assertFalse(uri.contains("codes=mz,mz"), "URL must not contain duplicate boundary codes");
+        assertTrue(uri.contains("limit=1"), "limit should equal the unique code count");
+    }
+
+    @Test
+    @DisplayName("Should not throw when all (deduplicated) boundary codes are valid")
+    void shouldPassWhenAllBoundaryCodesAreValid() {
+        ReflectionTestUtils.setField(boundaryV2Util, "boundaryHost", "http://boundary");
+        ReflectionTestUtils.setField(boundaryV2Util, "boundarySearchUrl", "/boundary-service/boundary/_search");
+
+        Map<String, List<String>> boundaries = Collections.singletonMap("Country", Arrays.asList("mz", "mz"));
+
+        when(serviceRequestClient.fetchResult(any(), any(), eq(BoundaryResponse.class)))
+                .thenReturn(boundaryResponse("mz"));
+
+        // Should complete without throwing
+        boundaryV2Util.validateBoundaryDetails(boundaries, "mz", RequestInfo.builder().build(), "ADMIN");
+    }
+}

--- a/health-services/project/src/test/java/org/egov/project/util/BoundaryV2UtilTest.java
+++ b/health-services/project/src/test/java/org/egov/project/util/BoundaryV2UtilTest.java
@@ -11,6 +11,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.egov.tracer.model.CustomException;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Arrays;
@@ -20,6 +21,7 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -77,5 +79,24 @@ public class BoundaryV2UtilTest {
 
         // Should complete without throwing
         boundaryV2Util.validateBoundaryDetails(boundaries, "mz", RequestInfo.builder().build(), "ADMIN");
+    }
+
+    @Test
+    @DisplayName("Should report invalid codes (not NPE) when the service returns an empty 200 with a null Boundary list")
+    void shouldReportInvalidCodesWhenResponseBoundaryIsNull() {
+        ReflectionTestUtils.setField(boundaryV2Util, "boundaryHost", "http://boundary");
+        ReflectionTestUtils.setField(boundaryV2Util, "boundarySearchUrl", "/boundary-service/boundary/_search");
+
+        Map<String, List<String>> boundaries = Collections.singletonMap("Country", Collections.singletonList("mz"));
+
+        // Empty 200: BoundaryResponse with a null Boundary list (the default)
+        when(serviceRequestClient.fetchResult(any(), any(), eq(BoundaryResponse.class)))
+                .thenReturn(new BoundaryResponse());
+
+        CustomException ex = assertThrows(CustomException.class, () ->
+                boundaryV2Util.validateBoundaryDetails(boundaries, "mz", RequestInfo.builder().build(), "ADMIN"));
+        // Guard must yield a meaningful "boundary not available" message for the code, not a masked NPE
+        assertTrue(ex.getMessage().contains("mz"),
+                "Exception should surface the unavailable boundary code, not a NullPointerException");
     }
 }


### PR DESCRIPTION
Problem
  Bulk project create (POST /health-project/v1/_create) failed with BOUNDARY_SERVICE_SEARCH_ERROR → No value specified for parameter 5 whenever two or more projects shared the same boundary
  code. The project service collected boundary codes into a list without dedup and sent codes=mz,mz to the Boundary Service, which then generated more SQL placeholders than bound values and
  left a parameter unbound.

  Fix
  Deduplicate boundary codes on our side before calling the Boundary Service (one lookup per unique code, applied to all projects sharing it):
  - ProjectValidator.getBoundaryForValidation() — collect codes per boundaryType into a LinkedHashSet (O(n), insertion order preserved).
  - BoundaryV2Util.validateBoundaryDetails() — .distinct() guard when flattening codes for the search URL.

