### PR TITLE
made beneficiary id limits tenant specific

### DIFF
--- a/core-services/beneficiary-idgen/pom.xml
+++ b/core-services/beneficiary-idgen/pom.xml
@@ -94,6 +94,10 @@
       <version>1.1.3-SNAPSHOT</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+    </dependency>
   </dependencies>
   <dependencyManagement>
     <dependencies>

--- a/core-services/beneficiary-idgen/src/main/java/org/egov/id/config/MainConfiguration.java
+++ b/core-services/beneficiary-idgen/src/main/java/org/egov/id/config/MainConfiguration.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.github.benmanes.caffeine.cache.Ticker;
 import org.egov.tracer.config.TracerConfiguration;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
@@ -60,5 +61,10 @@ public class MainConfiguration {
         MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();
         converter.setObjectMapper(objectMapper);
         return converter;
+    }
+
+    @Bean
+    public Ticker caffeineTicker() {
+        return Ticker.systemTicker();
     }
 }

--- a/core-services/beneficiary-idgen/src/main/java/org/egov/id/config/PropertiesManager.java
+++ b/core-services/beneficiary-idgen/src/main/java/org/egov/id/config/PropertiesManager.java
@@ -1,5 +1,6 @@
 package org.egov.id.config;
 
+import org.egov.id.model.DispatchLimitConfig;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 
@@ -108,5 +109,25 @@ public class PropertiesManager {
 	}
 	public String getIdPoolBulkCreateTopic() {
 		return environment.getProperty("kafka.topics.consumer.bulk.create.topic");
+	}
+
+	public String getMdmsDispatchLimitModule() {
+		return environment.getProperty("mdms.dispatch.limit.module", "beneficiary-idgen");
+	}
+
+	public String getMdmsDispatchLimitMaster() {
+		return environment.getProperty("mdms.dispatch.limit.master", "IdDispatchConfig");
+	}
+
+	public int getDispatchLimitCacheTtlMinutes() {
+		return Integer.parseInt(environment.getProperty("dispatch.limit.cache.ttl.minutes", "30"));
+	}
+
+	public DispatchLimitConfig getDefaultDispatchLimitConfig() {
+		return DispatchLimitConfig.builder()
+				.perDayEnabled(isDispatchLimitUserDevicePerDayEnabled())
+				.totalLimit(getDispatchLimitUserDeviceTotal())
+				.perDayLimit(getDispatchLimitUserDevicePerDay())
+				.build();
 	}
 }

--- a/core-services/beneficiary-idgen/src/main/java/org/egov/id/config/PropertiesManager.java
+++ b/core-services/beneficiary-idgen/src/main/java/org/egov/id/config/PropertiesManager.java
@@ -128,6 +128,9 @@ public class PropertiesManager {
 				.perDayEnabled(isDispatchLimitUserDevicePerDayEnabled())
 				.totalLimit(getDispatchLimitUserDeviceTotal())
 				.perDayLimit(getDispatchLimitUserDevicePerDay())
+				.perDayExpireDays(getDispatchUsageUserDevicePerDayExpireDays())
+				.totalExpireDays(getDispatchUsageUserDeviceTotalExpireDays())
+				.restrictToTodayEnabled(isIdDispatchRetrievalRestrictToTodayEnabled())
 				.build();
 	}
 }

--- a/core-services/beneficiary-idgen/src/main/java/org/egov/id/config/PropertiesManager.java
+++ b/core-services/beneficiary-idgen/src/main/java/org/egov/id/config/PropertiesManager.java
@@ -1,6 +1,7 @@
 package org.egov.id.config;
 
 import org.egov.id.model.DispatchLimitConfig;
+import org.egov.id.model.IdPoolConfig;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 
@@ -131,6 +132,13 @@ public class PropertiesManager {
 				.perDayExpireDays(getDispatchUsageUserDevicePerDayExpireDays())
 				.totalExpireDays(getDispatchUsageUserDeviceTotalExpireDays())
 				.restrictToTodayEnabled(isIdDispatchRetrievalRestrictToTodayEnabled())
+				.build();
+	}
+
+	public IdPoolConfig getDefaultIdPoolConfig() {
+		return IdPoolConfig.builder()
+				.seqCode(environment.getProperty("id.pool.seq.code", "id.pool.number"))
+				.paddingLength(Integer.parseInt(environment.getProperty("id.pool.padding.length", "11")))
 				.build();
 	}
 }

--- a/core-services/beneficiary-idgen/src/main/java/org/egov/id/config/PropertiesManager.java
+++ b/core-services/beneficiary-idgen/src/main/java/org/egov/id/config/PropertiesManager.java
@@ -120,6 +120,14 @@ public class PropertiesManager {
 		return environment.getProperty("mdms.dispatch.limit.master", "IdDispatchConfig");
 	}
 
+	public String getMdmsIdPoolModule() {
+		return environment.getProperty("mdms.id.pool.module", "beneficiary-idgen");
+	}
+
+	public String getMdmsIdPoolMaster() {
+		return environment.getProperty("mdms.id.pool.master", "IdPoolConfig");
+	}
+
 	public int getDispatchLimitCacheTtlMinutes() {
 		return Integer.parseInt(environment.getProperty("dispatch.limit.cache.ttl.minutes", "30"));
 	}

--- a/core-services/beneficiary-idgen/src/main/java/org/egov/id/config/PropertiesManager.java
+++ b/core-services/beneficiary-idgen/src/main/java/org/egov/id/config/PropertiesManager.java
@@ -1,16 +1,20 @@
 package org.egov.id.config;
 
+import lombok.extern.slf4j.Slf4j;
 import org.egov.id.model.DispatchLimitConfig;
 import org.egov.id.model.IdPoolConfig;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.EventListener;
 import org.springframework.core.env.Environment;
 
 /**
- * 
+ *
  * @author Yosadhara
  *
  */
 @Configuration
+@Slf4j
 public class PropertiesManager {
 
 	private final Environment environment;
@@ -143,10 +147,32 @@ public class PropertiesManager {
 				.build();
 	}
 
+	/**
+	 * Surfaces a missing service-level 'id.pool.seq.code' at startup as a loud, operator-visible warning.
+	 *
+	 * This is intentionally a warning and not a hard boot failure: a deployment may legitimately supply
+	 * seqCode per-tenant via MDMS IdPoolConfig and omit the service-level default, in which case a hard
+	 * fail would be wrong. But when neither is present, ID pool generation aborts per request (see
+	 * {@code IdGenerationService.fetchIdFormat}), and that failure is otherwise only visible in a per-message
+	 * error log. Emitting it at startup makes the misconfiguration visible where operators actually look.
+	 */
+	@EventListener(ApplicationReadyEvent.class)
+	public void warnIfSeqCodeMissing() {
+		String seqCode = environment.getProperty("id.pool.seq.code");
+		if (seqCode == null || seqCode.isBlank()) {
+			log.warn("Configuration 'id.pool.seq.code' is not set. ID pool generation will fail for any tenant "
+					+ "that does not provide its own 'seqCode' via MDMS IdPoolConfig. Set 'id.pool.seq.code' at the "
+					+ "service level unless every tenant defines seqCode in MDMS.");
+		}
+	}
+
 	public IdPoolConfig getDefaultIdPoolConfig() {
+		// seqCode has no code-level fallback on purpose: a genuinely unset 'id.pool.seq.code' must
+		// surface as a loud configuration error (see IdGenerationService.fetchIdFormat) rather than
+		// silently generating IDs from an unintended default sequence.
 		return IdPoolConfig.builder()
-				.seqCode(environment.getProperty("id.pool.seq.code", "id.pool.number"))
-				.paddingLength(Integer.parseInt(environment.getProperty("id.pool.padding.length", "11")))
+				.seqCode(environment.getProperty("id.pool.seq.code"))
+				.paddingLength(Integer.parseInt(environment.getProperty("id.pool.padding.length", "12")))
 				.build();
 	}
 }

--- a/core-services/beneficiary-idgen/src/main/java/org/egov/id/model/DispatchLimitConfig.java
+++ b/core-services/beneficiary-idgen/src/main/java/org/egov/id/model/DispatchLimitConfig.java
@@ -9,4 +9,7 @@ public class DispatchLimitConfig {
     boolean perDayEnabled;
     int totalLimit;
     int perDayLimit;
+    int perDayExpireDays;
+    int totalExpireDays;
+    boolean restrictToTodayEnabled;
 }

--- a/core-services/beneficiary-idgen/src/main/java/org/egov/id/model/DispatchLimitConfig.java
+++ b/core-services/beneficiary-idgen/src/main/java/org/egov/id/model/DispatchLimitConfig.java
@@ -1,0 +1,12 @@
+package org.egov.id.model;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class DispatchLimitConfig {
+    boolean perDayEnabled;
+    int totalLimit;
+    int perDayLimit;
+}

--- a/core-services/beneficiary-idgen/src/main/java/org/egov/id/model/IdPoolConfig.java
+++ b/core-services/beneficiary-idgen/src/main/java/org/egov/id/model/IdPoolConfig.java
@@ -1,0 +1,12 @@
+package org.egov.id.model;
+
+import lombok.Builder;
+import lombok.Value;
+
+@Value
+@Builder
+public class IdPoolConfig {
+    String seqCode;
+    int paddingLength;
+}
+

--- a/core-services/beneficiary-idgen/src/main/java/org/egov/id/service/DispatchLimitCacheService.java
+++ b/core-services/beneficiary-idgen/src/main/java/org/egov/id/service/DispatchLimitCacheService.java
@@ -11,7 +11,6 @@ import org.egov.id.model.DispatchLimitConfig;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 @Service
@@ -20,13 +19,11 @@ public class DispatchLimitCacheService {
 
     private final PropertiesManager propertiesManager;
     private final MdmsService mdmsService;
-    private final ConcurrentHashMap<String, DispatchLimitConfig> lastKnownConfigs;
     private final Cache<String, DispatchLimitConfig> cache;
 
     public DispatchLimitCacheService(PropertiesManager propertiesManager, MdmsService mdmsService, Ticker ticker) {
         this.propertiesManager = propertiesManager;
         this.mdmsService = mdmsService;
-        this.lastKnownConfigs = new ConcurrentHashMap<>();
         this.cache = Caffeine.newBuilder()
                 .expireAfterWrite(propertiesManager.getDispatchLimitCacheTtlMinutes(), TimeUnit.MINUTES)
                 .ticker(ticker)
@@ -44,7 +41,6 @@ public class DispatchLimitCacheService {
         try {
             Optional<DispatchLimitConfig> mdmsConfig = mdmsService.getDispatchLimitConfig(requestInfo, tenantId);
             if (mdmsConfig.isPresent()) {
-                lastKnownConfigs.put(tenantId, mdmsConfig.get());
                 return mdmsConfig.get();
             }
             log.debug("Using default dispatch limit config for tenantId={}", tenantId);

--- a/core-services/beneficiary-idgen/src/main/java/org/egov/id/service/DispatchLimitCacheService.java
+++ b/core-services/beneficiary-idgen/src/main/java/org/egov/id/service/DispatchLimitCacheService.java
@@ -1,0 +1,65 @@
+package org.egov.id.service;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.egov.common.contract.request.RequestInfo;
+import org.egov.id.config.PropertiesManager;
+import org.egov.id.model.DispatchLimitConfig;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@Slf4j
+public class DispatchLimitCacheService {
+
+    private final PropertiesManager propertiesManager;
+    private final MdmsService mdmsService;
+    private final ConcurrentHashMap<String, DispatchLimitConfig> lastKnownConfigs;
+    private final Cache<String, DispatchLimitConfig> cache;
+
+    public DispatchLimitCacheService(PropertiesManager propertiesManager, MdmsService mdmsService) {
+        this.propertiesManager = propertiesManager;
+        this.mdmsService = mdmsService;
+        this.lastKnownConfigs = new ConcurrentHashMap<>();
+        this.cache = Caffeine.newBuilder()
+                .expireAfterWrite(propertiesManager.getDispatchLimitCacheTtlMinutes(), TimeUnit.MINUTES)
+                .build();
+    }
+
+    public DispatchLimitConfig getEffectiveLimitConfig(String tenantId, RequestInfo requestInfo) {
+        if (StringUtils.isBlank(tenantId)) {
+            return propertiesManager.getDefaultDispatchLimitConfig();
+        }
+        String normalizedTenantId = normalizeTenantId(tenantId);
+        return cache.get(normalizedTenantId, key -> loadConfig(key, requestInfo));
+    }
+
+    private DispatchLimitConfig loadConfig(String tenantId, RequestInfo requestInfo) {
+        try {
+            Optional<DispatchLimitConfig> mdmsConfig = mdmsService.getDispatchLimitConfig(requestInfo, tenantId);
+            if (mdmsConfig.isPresent()) {
+                lastKnownConfigs.put(tenantId, mdmsConfig.get());
+                return mdmsConfig.get();
+            }
+            log.debug("Using default dispatch limit config for tenantId={}", tenantId);
+            return propertiesManager.getDefaultDispatchLimitConfig();
+        } catch (Exception e) {
+            log.error("Failed to fetch dispatch limit config from MDMS for tenantId={}", tenantId, e);
+            DispatchLimitConfig staleConfig = lastKnownConfigs.get(tenantId);
+            if (staleConfig != null) {
+                log.warn("Using stale dispatch limit config for tenantId={}", tenantId);
+                return staleConfig;
+            }
+            return propertiesManager.getDefaultDispatchLimitConfig();
+        }
+    }
+
+    private String normalizeTenantId(String tenantId) {
+        return tenantId.toLowerCase();
+    }
+}

--- a/core-services/beneficiary-idgen/src/main/java/org/egov/id/service/DispatchLimitCacheService.java
+++ b/core-services/beneficiary-idgen/src/main/java/org/egov/id/service/DispatchLimitCacheService.java
@@ -2,6 +2,7 @@ package org.egov.id.service;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.Ticker;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.egov.common.contract.request.RequestInfo;
@@ -22,12 +23,13 @@ public class DispatchLimitCacheService {
     private final ConcurrentHashMap<String, DispatchLimitConfig> lastKnownConfigs;
     private final Cache<String, DispatchLimitConfig> cache;
 
-    public DispatchLimitCacheService(PropertiesManager propertiesManager, MdmsService mdmsService) {
+    public DispatchLimitCacheService(PropertiesManager propertiesManager, MdmsService mdmsService, Ticker ticker) {
         this.propertiesManager = propertiesManager;
         this.mdmsService = mdmsService;
         this.lastKnownConfigs = new ConcurrentHashMap<>();
         this.cache = Caffeine.newBuilder()
                 .expireAfterWrite(propertiesManager.getDispatchLimitCacheTtlMinutes(), TimeUnit.MINUTES)
+                .ticker(ticker)
                 .build();
     }
 
@@ -35,8 +37,7 @@ public class DispatchLimitCacheService {
         if (StringUtils.isBlank(tenantId)) {
             return propertiesManager.getDefaultDispatchLimitConfig();
         }
-        String normalizedTenantId = normalizeTenantId(tenantId);
-        return cache.get(normalizedTenantId, key -> loadConfig(key, requestInfo));
+        return cache.get(tenantId, key -> loadConfig(key, requestInfo));
     }
 
     private DispatchLimitConfig loadConfig(String tenantId, RequestInfo requestInfo) {
@@ -50,16 +51,7 @@ public class DispatchLimitCacheService {
             return propertiesManager.getDefaultDispatchLimitConfig();
         } catch (Exception e) {
             log.error("Failed to fetch dispatch limit config from MDMS for tenantId={}", tenantId, e);
-            DispatchLimitConfig staleConfig = lastKnownConfigs.get(tenantId);
-            if (staleConfig != null) {
-                log.warn("Using stale dispatch limit config for tenantId={}", tenantId);
-                return staleConfig;
-            }
-            return propertiesManager.getDefaultDispatchLimitConfig();
+            throw e;
         }
-    }
-
-    private String normalizeTenantId(String tenantId) {
-        return tenantId.toLowerCase();
     }
 }

--- a/core-services/beneficiary-idgen/src/main/java/org/egov/id/service/DispatchLimitCacheService.java
+++ b/core-services/beneficiary-idgen/src/main/java/org/egov/id/service/DispatchLimitCacheService.java
@@ -10,7 +10,9 @@ import org.egov.id.config.PropertiesManager;
 import org.egov.id.model.DispatchLimitConfig;
 import org.springframework.stereotype.Service;
 
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
 @Service
@@ -20,6 +22,13 @@ public class DispatchLimitCacheService {
     private final PropertiesManager propertiesManager;
     private final MdmsService mdmsService;
     private final Cache<String, DispatchLimitConfig> cache;
+
+    /**
+     * Last successfully resolved config per tenant. Unlike {@link #cache}, this is never
+     * evicted on TTL expiry, so it can serve a stale-but-usable value when MDMS is unavailable
+     * on a refresh, keeping ID dispatch off MDMS's failure path.
+     */
+    private final Map<String, DispatchLimitConfig> lastKnownConfig = new ConcurrentHashMap<>();
 
     public DispatchLimitCacheService(PropertiesManager propertiesManager, MdmsService mdmsService, Ticker ticker) {
         this.propertiesManager = propertiesManager;
@@ -34,20 +43,36 @@ public class DispatchLimitCacheService {
         if (StringUtils.isBlank(tenantId)) {
             return propertiesManager.getDefaultDispatchLimitConfig();
         }
-        return cache.get(tenantId, key -> loadConfig(key, requestInfo));
+        DispatchLimitConfig config = cache.get(tenantId, key -> loadConfig(key, requestInfo));
+        if (config != null) {
+            return config;
+        }
+        // loadConfig returned null: the MDMS lookup failed and Caffeine recorded no mapping (see below),
+        // so this failure is NOT pinned in the cache and the next request will retry MDMS. Resolve a
+        // usable value here without caching it - last-known if this tenant ever loaded successfully,
+        // otherwise the service default.
+        DispatchLimitConfig stale = lastKnownConfig.get(tenantId);
+        return stale != null ? stale : propertiesManager.getDefaultDispatchLimitConfig();
     }
 
     private DispatchLimitConfig loadConfig(String tenantId, RequestInfo requestInfo) {
         try {
             Optional<DispatchLimitConfig> mdmsConfig = mdmsService.getDispatchLimitConfig(requestInfo, tenantId);
+            DispatchLimitConfig resolved;
             if (mdmsConfig.isPresent()) {
-                return mdmsConfig.get();
+                resolved = mdmsConfig.get();
+            } else {
+                log.debug("Using default dispatch limit config for tenantId={}", tenantId);
+                resolved = propertiesManager.getDefaultDispatchLimitConfig();
             }
-            log.debug("Using default dispatch limit config for tenantId={}", tenantId);
-            return propertiesManager.getDefaultDispatchLimitConfig();
+            lastKnownConfig.put(tenantId, resolved);
+            return resolved;
         } catch (Exception e) {
-            log.error("Failed to fetch dispatch limit config from MDMS for tenantId={}", tenantId, e);
-            throw e;
+            // Return null so Caffeine records NO mapping for this key. Caching the fallback here would
+            // pin the tenant to it for the full TTL even after MDMS recovers seconds later; returning
+            // null lets the caller degrade gracefully while the next request retries MDMS.
+            log.error("Failed to fetch dispatch limit config from MDMS for tenantId={}; degrading and will retry on next request", tenantId, e);
+            return null;
         }
     }
 }

--- a/core-services/beneficiary-idgen/src/main/java/org/egov/id/service/IdDispatchService.java
+++ b/core-services/beneficiary-idgen/src/main/java/org/egov/id/service/IdDispatchService.java
@@ -112,21 +112,22 @@ public class IdDispatchService {
 
         DispatchLimitConfig limitConfig = dispatchLimitCacheService.getEffectiveLimitConfig(tenantId, requestInfo);
         long totalLimit = limitConfig.isPerDayEnabled() ? limitConfig.getPerDayLimit() : limitConfig.getTotalLimit();
+        boolean restrictToTodayEnabled = limitConfig.isRestrictToTodayEnabled();
 
         // Handle special case: if client requests fetching previously allocated IDs instead of new dispatch
         if (!ObjectUtils.isEmpty(request.getClientInfo().getFetchAllocatedIds())
                 && request.getClientInfo().getFetchAllocatedIds()) {
             // Get count of IDs already dispatched to this user and device from Redis cache
-            long remainingCount = redissonIDService.getUserDeviceDispatchedIDRemaining(tenantId, userUuid, deviceUuid, false, propertiesManager.isIdDispatchRetrievalRestrictToTodayEnabled(),requestInfo);
+            long remainingCount = redissonIDService.getUserDeviceDispatchedIDRemaining(tenantId, userUuid, deviceUuid, false, restrictToTodayEnabled, limitConfig);
             log.debug("FetchAllocatedIds flag is true, fetching previously allocated IDs.");
 
             // Fetch all IDs already dispatched to this user/device
-            Tuple<IdDispatchResponse, Long> idDispatchLogs = fetchAllUserDeviceIds(request, limit, offset, propertiesManager.isIdDispatchRetrievalRestrictToTodayEnabled());
+            Tuple<IdDispatchResponse, Long> idDispatchLogs = fetchAllUserDeviceIds(request, limit, offset, restrictToTodayEnabled);
             IdDispatchResponse idDispatchResponse = idDispatchLogs.getX();
             Long totalCount = idDispatchLogs.getY();
             long actualRemainingCount = totalLimit - totalCount;
             if(remainingCount != actualRemainingCount) {
-                redissonIDService.updateUserDeviceDispatchedIDCount(tenantId, userUuid, deviceUuid, totalCount, false, propertiesManager.isIdDispatchRetrievalRestrictToTodayEnabled());
+                redissonIDService.updateUserDeviceDispatchedIDCount(tenantId, userUuid, deviceUuid, totalCount, false, restrictToTodayEnabled, limitConfig);
             }
             // Set fetch limits in the response and return
             idDispatchResponse.setFetchLimit(Math.max(0, totalCount - (offset + idDispatchResponse.getIdResponses().size())));
@@ -136,7 +137,7 @@ public class IdDispatchService {
         }
 
         // Get count of IDs already dispatched to this user and device from Redis cache
-        long remainingCount = redissonIDService.getUserDeviceDispatchedIDRemaining(tenantId, userUuid, deviceUuid, true, true, requestInfo);
+        long remainingCount = redissonIDService.getUserDeviceDispatchedIDRemaining(tenantId, userUuid, deviceUuid, true, true, limitConfig);
         long fetchCount = Math.min(remainingCount, count);
 
         List<IdRecord> idRecordsToDispatch = idRepo.fetchUnassigned(tenantId, userUuid, (int) fetchCount);
@@ -149,7 +150,7 @@ public class IdDispatchService {
         updateStatusesAndLogs(idRecordsToDispatch, userUuid, deviceUuid,
                 request.getClientInfo().getDeviceInfo(), tenantId, requestInfo);
 
-        redissonIDService.updateUserDeviceDispatchedIDCount(tenantId, userUuid, deviceUuid, idRecordsToDispatch.size(), true, true);
+        redissonIDService.updateUserDeviceDispatchedIDCount(tenantId, userUuid, deviceUuid, idRecordsToDispatch.size(), true, true, limitConfig);
 
         idRecordsToDispatch.forEach(IdDispatchService::normalizeAdditionalFields);
 

--- a/core-services/beneficiary-idgen/src/main/java/org/egov/id/service/IdDispatchService.java
+++ b/core-services/beneficiary-idgen/src/main/java/org/egov/id/service/IdDispatchService.java
@@ -13,6 +13,7 @@ import org.egov.common.models.Error;
 import org.egov.common.utils.CommonUtils;
 import org.egov.common.utils.ResponseInfoUtil;
 import org.egov.id.config.PropertiesManager;
+import org.egov.id.model.DispatchLimitConfig;
 import org.egov.id.producer.IdGenProducer;
 import org.egov.id.repository.IdRepository;
 import org.egov.id.validators.IdPoolValidatorForUpdate;
@@ -42,6 +43,7 @@ public class IdDispatchService {
     private final IdRepository idRepo;
     private final IdGenProducer idGenProducer;
     private final PropertiesManager propertiesManager;
+    private final DispatchLimitCacheService dispatchLimitCacheService;
 
     @Autowired
     private RedissonIDService redissonIDService;
@@ -66,11 +68,13 @@ public class IdDispatchService {
     public IdDispatchService(IdRepository idRepo,
                              IdGenProducer idGenProducer,
                              PropertiesManager propertiesManager,
+                             DispatchLimitCacheService dispatchLimitCacheService,
                              List<Validator<IdRecordBulkRequest, IdRecord>> validators,
                              EnrichmentService enrichmentservice) {
         this.idRepo = idRepo;
         this.idGenProducer = idGenProducer;
         this.propertiesManager = propertiesManager;
+        this.dispatchLimitCacheService = dispatchLimitCacheService;
         this.validators = validators;
         this.enrichmentService  = enrichmentservice;
     }
@@ -106,16 +110,14 @@ public class IdDispatchService {
         // Log incoming dispatch request details
         log.debug("Dispatch request received: userUuid={}, deviceUuid={}, tenantId={}, count={}", userUuid, deviceUuid, tenantId, count);
 
-        long totalLimit = propertiesManager.getDispatchLimitUserDeviceTotal();
-        if (propertiesManager.isDispatchLimitUserDevicePerDayEnabled()) {
-            totalLimit = propertiesManager.getDispatchLimitUserDevicePerDay();
-        }
+        DispatchLimitConfig limitConfig = dispatchLimitCacheService.getEffectiveLimitConfig(tenantId, requestInfo);
+        long totalLimit = limitConfig.isPerDayEnabled() ? limitConfig.getPerDayLimit() : limitConfig.getTotalLimit();
 
         // Handle special case: if client requests fetching previously allocated IDs instead of new dispatch
         if (!ObjectUtils.isEmpty(request.getClientInfo().getFetchAllocatedIds())
                 && request.getClientInfo().getFetchAllocatedIds()) {
             // Get count of IDs already dispatched to this user and device from Redis cache
-            long remainingCount = redissonIDService.getUserDeviceDispatchedIDRemaining(tenantId, userUuid, deviceUuid, false, propertiesManager.isIdDispatchRetrievalRestrictToTodayEnabled());
+            long remainingCount = redissonIDService.getUserDeviceDispatchedIDRemaining(tenantId, userUuid, deviceUuid, false, propertiesManager.isIdDispatchRetrievalRestrictToTodayEnabled(),requestInfo);
             log.debug("FetchAllocatedIds flag is true, fetching previously allocated IDs.");
 
             // Fetch all IDs already dispatched to this user/device
@@ -134,7 +136,7 @@ public class IdDispatchService {
         }
 
         // Get count of IDs already dispatched to this user and device from Redis cache
-        long remainingCount = redissonIDService.getUserDeviceDispatchedIDRemaining(tenantId, userUuid, deviceUuid, true, true);
+        long remainingCount = redissonIDService.getUserDeviceDispatchedIDRemaining(tenantId, userUuid, deviceUuid, true, true, requestInfo);
         long fetchCount = Math.min(remainingCount, count);
 
         List<IdRecord> idRecordsToDispatch = idRepo.fetchUnassigned(tenantId, userUuid, (int) fetchCount);

--- a/core-services/beneficiary-idgen/src/main/java/org/egov/id/service/IdGenerationService.java
+++ b/core-services/beneficiary-idgen/src/main/java/org/egov/id/service/IdGenerationService.java
@@ -13,6 +13,7 @@ import org.egov.common.contract.request.RequestInfo;
 import org.egov.common.models.idgen.*;
 import org.egov.common.utils.ResponseInfoUtil;
 import org.egov.id.config.PropertiesManager;
+import org.egov.id.model.IdPoolConfig;
 import org.egov.id.producer.IdGenProducer;
 import org.egov.tracer.model.CustomException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -60,9 +61,6 @@ public class IdGenerationService {
     //default count value
     public Integer defaultCount = 1;
 
-    @Value("${id.pool.seq.code}")
-    public String idPoolName;
-
     @Value("${idgen.random.buffer:5}")
     public Integer defaultBufferPercentage;
 
@@ -86,7 +84,6 @@ public class IdGenerationService {
      * Padding length for sequence numbers in generated IDs.
      * This ensures that sequence numbers are zero-padded to a fixed length for consistency.
      */
-    @Value("${id.pool.padding.length:12}")
     private Integer paddingLength;
 
     /**
@@ -184,10 +181,10 @@ public class IdGenerationService {
     private String fetchIdFormat(String tenantId, Integer batchSize, RequestInfo requestInfo) {
         log.info("Fetching ID format for tenantId={}, batchSize={}", tenantId, batchSize);
 
-        if (ObjectUtils.isEmpty(idPoolName)) {
-            log.error("Configuration Error - 'id.pool.seq.code' is not set.");
-            throw new CustomException("Configuration Error:", "Please configure the 'id.pool.seq.code' on the service level.");
-        }
+        IdPoolConfig idPoolConfig = mdmsService.getIdPoolConfig(requestInfo, tenantId)
+                .orElseGet(propertiesManager::getDefaultIdPoolConfig);
+        this.paddingLength = idPoolConfig.getPaddingLength();
+        String idPoolName = idPoolConfig.getSeqCode();
 
         IdRequest tempRequest = new IdRequest(idPoolName, tenantId, null, batchSize);
         String idFormat;
@@ -252,7 +249,10 @@ public class IdGenerationService {
             String idFormat = fetchIdFormat(tenantId, chunkSize, requestInfo);
             // Adjust batch size if ID format contains random patterns
             Integer adjustedSize = adjustBatchSizeIfRandom(chunkSize, idFormat);
-            IdRequest idRequest = new IdRequest(idPoolName, tenantId, null, adjustedSize);
+            IdPoolConfig idPoolConfig = mdmsService.getIdPoolConfig(requestInfo, tenantId)
+                    .orElseGet(propertiesManager::getDefaultIdPoolConfig);
+            this.paddingLength = idPoolConfig.getPaddingLength();
+            IdRequest idRequest = new IdRequest(idPoolConfig.getSeqCode(), tenantId, null, adjustedSize);
             // Generate IDs
             List<String> generatedIds = generateIds(idRequest, requestInfo);
             // Persist generated IDs to Kafka

--- a/core-services/beneficiary-idgen/src/main/java/org/egov/id/service/IdGenerationService.java
+++ b/core-services/beneficiary-idgen/src/main/java/org/egov/id/service/IdGenerationService.java
@@ -81,10 +81,12 @@ public class IdGenerationService {
     private static final Pattern RANDOM_PATTERN = Pattern.compile("\\[d\\{\\d+}]");
 
     /**
-     * Padding length for sequence numbers in generated IDs.
-     * This ensures that sequence numbers are zero-padded to a fixed length for consistency.
+     * Default zero-padding width for sequence numbers on the non-pool ID generation path,
+     * where no per-tenant pool config is available. Immutable after injection, so it is safe
+     * to read from the shared singleton across concurrent requests.
      */
-    private Integer paddingLength;
+    @Value("${id.pool.padding.length:12}")
+    private int defaultPaddingLength;
 
     /**
      * Description : This method to generate idGenerationResponse
@@ -103,7 +105,8 @@ public class IdGenerationService {
         IdGenerationResponse idGenerationResponse = new IdGenerationResponse();
 
         for (IdRequest idRequest : idRequests) {
-            List<String> generatedId = generateIdFromIdRequest(idRequest, requestInfo);
+            // Non-pool API path has no per-tenant pool config; use the configured default padding length.
+            List<String> generatedId = generateIdFromIdRequest(idRequest, requestInfo, defaultPaddingLength);
             for (String ListOfIds : generatedId) {
                 IdResponse idResponse = new IdResponse();
                 idResponse.setId(ListOfIds);
@@ -181,8 +184,12 @@ public class IdGenerationService {
     private String fetchIdFormat(String tenantId, Integer batchSize, RequestInfo requestInfo, IdPoolConfig idPoolConfig) {
         log.info("Fetching ID format for tenantId={}, batchSize={}", tenantId, batchSize);
 
-        this.paddingLength = idPoolConfig.getPaddingLength();
         String idPoolName = idPoolConfig.getSeqCode();
+        if (ObjectUtils.isEmpty(idPoolName)) {
+            log.error("Configuration Error - sequence code is not set for tenantId={}", tenantId);
+            throw new CustomException("CONFIGURATION_ERROR",
+                    "Please configure 'id.pool.seq.code' at the service level or provide 'seqCode' in the tenant's IdPoolConfig.");
+        }
 
         IdRequest tempRequest = new IdRequest(idPoolName, tenantId, null, batchSize);
         String idFormat;
@@ -250,15 +257,21 @@ public class IdGenerationService {
             String idFormat = fetchIdFormat(tenantId, chunkSize, requestInfo, idPoolConfig);
             // Adjust batch size if ID format contains random patterns
             Integer adjustedSize = adjustBatchSizeIfRandom(chunkSize, idFormat);
-            this.paddingLength = idPoolConfig.getPaddingLength();
             IdRequest idRequest = new IdRequest(idPoolConfig.getSeqCode(), tenantId, null, adjustedSize);
-            // Generate IDs
-            List<String> generatedIds = generateIds(idRequest, requestInfo);
+            // Generate IDs, threading the tenant's padding length through instead of mutating shared state
+            List<String> generatedIds = generateIds(idRequest, requestInfo, idPoolConfig.getPaddingLength());
             // Persist generated IDs to Kafka
             persistToKafka(requestInfo, generatedIds, tenantId);
             log.info("Async ID pool generated and sent to Kafka for tenant {}", tenantId);
+        } catch (CustomException e) {
+            // Non-retryable: misconfiguration or invalid input (e.g. missing seqCode, unsafe/blank tenantId,
+            // non-positive batch size). Redelivering the same Kafka message would fail identically, so it is
+            // not rethrown. Logged distinctly from transient failures so misconfiguration is greppable/alertable
+            // rather than buried among transient MDMS/DB errors.
+            log.error("Non-retryable configuration/validation error in async ID pool generation for tenantId={}; "
+                    + "message dropped, operator action required. code={}", request.getTenantId(), e.getCode(), e);
         } catch (Exception e) {
-            log.error("Error in async ID pool generation", e);
+            log.error("Error in async ID pool generation for tenantId={}", request.getTenantId(), e);
         }
     }
 
@@ -268,14 +281,16 @@ public class IdGenerationService {
      *
      * @param idRequest the ID request containing pool name, tenant, and batch size details
      * @param requestInfo contextual request info for auditing and logging
+     * @param paddingLength zero-padding width for generated sequence numbers
      * @return list of generated ID strings
      * @throws RuntimeException if ID generation fails
      */
-    private List<String> generateIds(IdRequest idRequest, RequestInfo requestInfo) {
+    private List<String> generateIds(IdRequest idRequest, RequestInfo requestInfo, int paddingLength) {
         try {
-            return generateIdFromIdRequest(idRequest, requestInfo);
+            return generateIdFromIdRequest(idRequest, requestInfo, paddingLength);
+        } catch (CustomException e) {
+            throw e;
         } catch (Exception e) {
-            log.error("Error generating IDs: ", e);
             throw new RuntimeException("Error generating IDs", e);
         }
     }
@@ -346,7 +361,7 @@ public class IdGenerationService {
      * @return generatedId
      * @throws Exception
      */
-    private List generateIdFromIdRequest(IdRequest idRequest, RequestInfo requestInfo) throws Exception {
+    private List generateIdFromIdRequest(IdRequest idRequest, RequestInfo requestInfo, int paddingLength) throws Exception {
 
         List<String> generatedId = new LinkedList<>();
         boolean autoCreateNewSeqFlag = false;
@@ -369,7 +384,7 @@ public class IdGenerationService {
             throw new CustomException("ID_NOT_FOUND",
                     "No Format is available in the MDMS for the given name and tenant");
 
-        return getFormattedId(idRequest, requestInfo,autoCreateNewSeqFlag);
+        return getFormattedId(idRequest, requestInfo, autoCreateNewSeqFlag, paddingLength);
     }
 
     /**
@@ -434,7 +449,7 @@ public class IdGenerationService {
      * @throws Exception
      */
 
-    private List<String> getFormattedId(IdRequest idRequest, RequestInfo requestInfo, boolean autoCreateNewSeqFlag) throws Exception {
+    private List<String> getFormattedId(IdRequest idRequest, RequestInfo requestInfo, boolean autoCreateNewSeqFlag, int paddingLength) throws Exception {
         List<String> idFormatList = new LinkedList<>();
         String idFormat = idRequest.getFormat();
 
@@ -472,7 +487,7 @@ public class IdGenerationService {
 
                 if (attributeName.substring(0, 3).equalsIgnoreCase("seq")) {
                     if (!sequences.containsKey(attributeName)) {
-                        sequences.put(attributeName, generateSequenceNumber(attributeName, requestInfo, idRequest,autoCreateNewSeqFlag));
+                        sequences.put(attributeName, generateSequenceNumber(attributeName, requestInfo, idRequest, autoCreateNewSeqFlag, paddingLength));
                     }
 					idFormat = idFormat.replace("[" + attributeName + "]", sequences.get(attributeName).get(i));
                 } else if (attributeName.substring(0, 2).equalsIgnoreCase("fy")) {
@@ -645,9 +660,10 @@ public class IdGenerationService {
      *
      * @param sequenceName
      * @param requestInfo
+     * @param paddingLength zero-padding width for the generated sequence numbers
      * @return seqNumber
      */
-    private List<String> generateSequenceNumber(String sequenceName, RequestInfo requestInfo, IdRequest idRequest,boolean autoCreateNewSeqFlag) throws Exception {
+    private List<String> generateSequenceNumber(String sequenceName, RequestInfo requestInfo, IdRequest idRequest, boolean autoCreateNewSeqFlag, int paddingLength) throws Exception {
         Integer count = getCount(idRequest);
         List<String> sequenceList = new LinkedList<>();
         List<String> sequenceLists = new LinkedList<>();
@@ -675,8 +691,12 @@ public class IdGenerationService {
             log.error("Error retrieving seq number from DB",ex);
             throw new CustomException("SEQ_NUMBER_ERROR","Error retrieving seq number from existing seq in DB");
         }
+        // A non-positive width means "no zero-padding": guard against it because "%00d" is an invalid
+        // format spec that throws DuplicateFormatFlagsException at runtime (e.g. when a tenant's MDMS
+        // IdPoolConfig omits paddingLength, which deserializes to 0 on the primitive int field).
+        String seqFormat = paddingLength > 0 ? "%0" + paddingLength + "d" : "%d";
         for (String seqId : sequenceList) {
-            String seqNumber = String.format("%0" + paddingLength + "d", Long.parseLong(seqId));
+            String seqNumber = String.format(seqFormat, Long.parseLong(seqId));
             sequenceLists.add(seqNumber);
         }
         return sequenceLists;

--- a/core-services/beneficiary-idgen/src/main/java/org/egov/id/service/IdGenerationService.java
+++ b/core-services/beneficiary-idgen/src/main/java/org/egov/id/service/IdGenerationService.java
@@ -178,11 +178,9 @@ public class IdGenerationService {
      * @throws CustomException if configuration is missing or fetching format fails
      * @throws IllegalArgumentException if fetched ID format is null or empty
      */
-    private String fetchIdFormat(String tenantId, Integer batchSize, RequestInfo requestInfo) {
+    private String fetchIdFormat(String tenantId, Integer batchSize, RequestInfo requestInfo, IdPoolConfig idPoolConfig) {
         log.info("Fetching ID format for tenantId={}, batchSize={}", tenantId, batchSize);
 
-        IdPoolConfig idPoolConfig = mdmsService.getIdPoolConfig(requestInfo, tenantId)
-                .orElseGet(propertiesManager::getDefaultIdPoolConfig);
         this.paddingLength = idPoolConfig.getPaddingLength();
         String idPoolName = idPoolConfig.getSeqCode();
 
@@ -245,12 +243,13 @@ public class IdGenerationService {
                 throw new CustomException("INVALID_BATCH_SIZE", "Batch size must be > 0");
             }
 
-            // Fetch ID format and adjust batch size if necessary
-            String idFormat = fetchIdFormat(tenantId, chunkSize, requestInfo);
-            // Adjust batch size if ID format contains random patterns
-            Integer adjustedSize = adjustBatchSizeIfRandom(chunkSize, idFormat);
             IdPoolConfig idPoolConfig = mdmsService.getIdPoolConfig(requestInfo, tenantId)
                     .orElseGet(propertiesManager::getDefaultIdPoolConfig);
+
+            // Fetch ID format and adjust batch size if necessary
+            String idFormat = fetchIdFormat(tenantId, chunkSize, requestInfo, idPoolConfig);
+            // Adjust batch size if ID format contains random patterns
+            Integer adjustedSize = adjustBatchSizeIfRandom(chunkSize, idFormat);
             this.paddingLength = idPoolConfig.getPaddingLength();
             IdRequest idRequest = new IdRequest(idPoolConfig.getSeqCode(), tenantId, null, adjustedSize);
             // Generate IDs

--- a/core-services/beneficiary-idgen/src/main/java/org/egov/id/service/MdmsService.java
+++ b/core-services/beneficiary-idgen/src/main/java/org/egov/id/service/MdmsService.java
@@ -6,6 +6,8 @@ import java.util.*;
 import lombok.extern.log4j.Log4j2;
 import org.egov.common.contract.request.RequestInfo;
 import org.egov.common.models.idgen.*;
+import org.egov.id.config.PropertiesManager;
+import org.egov.id.model.DispatchLimitConfig;
 import org.egov.mdms.model.MasterDetail;
 import org.egov.mdms.model.MdmsCriteria;
 import org.egov.mdms.model.MdmsCriteriaReq;
@@ -25,6 +27,9 @@ public class MdmsService {
 
     @Autowired
     MdmsClientService mdmsClientService;
+
+    @Autowired
+    PropertiesManager propertiesManager;
 
     // 'tenants' & 'citymodule' are the JSON files inside the folder 'tenant'.
     private static final String tenantMaster = "tenants";
@@ -92,6 +97,61 @@ public class MdmsService {
             throw new CustomException("PARSING ERROR", "Failed to get formatid from MDMS");
         }
         return idFormat;
+    }
+
+    public Optional<DispatchLimitConfig> getDispatchLimitConfig(RequestInfo requestInfo, String tenantId) {
+        String module = propertiesManager.getMdmsDispatchLimitModule();
+        String master = propertiesManager.getMdmsDispatchLimitMaster();
+
+        MasterDetail masterDetail = MasterDetail.builder()
+                .name(master)
+                .filter("[?(@.tenantId=='" + tenantId + "' && (@.isActive==true || @.isActive==null))]")
+                .build();
+
+        Map<String, List<MasterDetail>> masterDetails = new HashMap<>();
+        masterDetails.put(module, Collections.singletonList(masterDetail));
+
+        MdmsResponse mdmsResponse = getMasterData(requestInfo, tenantId, masterDetails);
+
+        if (mdmsResponse.getMdmsRes() == null
+                || !mdmsResponse.getMdmsRes().containsKey(module)
+                || !mdmsResponse.getMdmsRes().get(module).containsKey(master)
+                || mdmsResponse.getMdmsRes().get(module).get(master).isEmpty()
+                || mdmsResponse.getMdmsRes().get(module).get(master).get(0) == null) {
+            log.debug("No dispatch limit config found in MDMS for tenantId={}", tenantId);
+            return Optional.empty();
+        }
+
+        Map<String, Object> configData = (Map<String, Object>) mdmsResponse.getMdmsRes().get(module).get(master).get(0);
+        DocumentContext documentContext = JsonPath.parse(configData);
+
+        boolean perDayEnabled = readBooleanField(documentContext, "perDayEnabled", true);
+        int totalLimit = readIntField(documentContext, "totalLimit", propertiesManager.getDispatchLimitUserDeviceTotal());
+        int perDayLimit = readIntField(documentContext, "perDayLimit", propertiesManager.getDispatchLimitUserDevicePerDay());
+
+        return Optional.of(DispatchLimitConfig.builder()
+                .perDayEnabled(perDayEnabled)
+                .totalLimit(totalLimit)
+                .perDayLimit(perDayLimit)
+                .build());
+    }
+
+    private boolean readBooleanField(DocumentContext documentContext, String field, boolean defaultValue) {
+        try {
+            Boolean value = documentContext.read("$." + field);
+            return value != null ? value : defaultValue;
+        } catch (Exception e) {
+            return defaultValue;
+        }
+    }
+
+    private int readIntField(DocumentContext documentContext, String field, int defaultValue) {
+        try {
+            Number value = documentContext.read("$." + field);
+            return value != null ? value.intValue() : defaultValue;
+        } catch (Exception e) {
+            return defaultValue;
+        }
     }
 
     /**

--- a/core-services/beneficiary-idgen/src/main/java/org/egov/id/service/MdmsService.java
+++ b/core-services/beneficiary-idgen/src/main/java/org/egov/id/service/MdmsService.java
@@ -125,14 +125,20 @@ public class MdmsService {
         Map<String, Object> configData = (Map<String, Object>) mdmsResponse.getMdmsRes().get(module).get(master).get(0);
         DocumentContext documentContext = JsonPath.parse(configData);
 
-        boolean perDayEnabled = readBooleanField(documentContext, "perDayEnabled", true);
+        boolean perDayEnabled = readBooleanField(documentContext, "perDayEnabled", propertiesManager.isDispatchLimitUserDevicePerDayEnabled());
         int totalLimit = readIntField(documentContext, "totalLimit", propertiesManager.getDispatchLimitUserDeviceTotal());
         int perDayLimit = readIntField(documentContext, "perDayLimit", propertiesManager.getDispatchLimitUserDevicePerDay());
+        int perDayExpireDays = readIntField(documentContext, "perDayExpireDays", propertiesManager.getDispatchUsageUserDevicePerDayExpireDays());
+        int totalExpireDays = readIntField(documentContext, "totalExpireDays", propertiesManager.getDispatchUsageUserDeviceTotalExpireDays());
+        boolean restrictToTodayEnabled = readBooleanField(documentContext, "restrictToTodayEnabled", propertiesManager.isIdDispatchRetrievalRestrictToTodayEnabled());
 
         return Optional.of(DispatchLimitConfig.builder()
                 .perDayEnabled(perDayEnabled)
                 .totalLimit(totalLimit)
                 .perDayLimit(perDayLimit)
+                .perDayExpireDays(perDayExpireDays)
+                .totalExpireDays(totalExpireDays)
+                .restrictToTodayEnabled(restrictToTodayEnabled)
                 .build());
     }
 

--- a/core-services/beneficiary-idgen/src/main/java/org/egov/id/service/MdmsService.java
+++ b/core-services/beneficiary-idgen/src/main/java/org/egov/id/service/MdmsService.java
@@ -101,6 +101,7 @@ public class MdmsService {
     }
 
     public Optional<DispatchLimitConfig> getDispatchLimitConfig(RequestInfo requestInfo, String tenantId) {
+        validateTenantIdForMdmsFilter(tenantId);
         String module = propertiesManager.getMdmsDispatchLimitModule();
         String master = propertiesManager.getMdmsDispatchLimitMaster();
         String filter = "[?(@.tenantId=='" + tenantId + "' && (@.isActive==true || @.isActive==null))]";
@@ -131,6 +132,7 @@ public class MdmsService {
     }
 
     public Optional<IdPoolConfig> getIdPoolConfig(RequestInfo requestInfo, String tenantId) {
+        validateTenantIdForMdmsFilter(tenantId);
         String module = propertiesManager.getMdmsIdPoolModule();
         if (module == null || module.isBlank()) {
             module = "beneficiary-idgen";
@@ -156,6 +158,15 @@ public class MdmsService {
                 .seqCode(seqCode)
                 .paddingLength(paddingLength)
                 .build());
+    }
+
+    private void validateTenantIdForMdmsFilter(String tenantId) {
+        if (tenantId == null || tenantId.isBlank()) {
+            throw new CustomException("INVALID_TENANT_ID", "TenantId cannot be null/blank");
+        }
+        if (!tenantId.matches("^[A-Za-z0-9._-]+$")) {
+            throw new CustomException("INVALID_TENANT_ID", "TenantId contains unsafe characters");
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/core-services/beneficiary-idgen/src/main/java/org/egov/id/service/MdmsService.java
+++ b/core-services/beneficiary-idgen/src/main/java/org/egov/id/service/MdmsService.java
@@ -8,6 +8,7 @@ import org.egov.common.contract.request.RequestInfo;
 import org.egov.common.models.idgen.*;
 import org.egov.id.config.PropertiesManager;
 import org.egov.id.model.DispatchLimitConfig;
+import org.egov.id.model.IdPoolConfig;
 import org.egov.mdms.model.MasterDetail;
 import org.egov.mdms.model.MdmsCriteria;
 import org.egov.mdms.model.MdmsCriteriaReq;
@@ -140,6 +141,48 @@ public class MdmsService {
                 .totalExpireDays(totalExpireDays)
                 .restrictToTodayEnabled(restrictToTodayEnabled)
                 .build());
+    }
+
+    public Optional<IdPoolConfig> getIdPoolConfig(RequestInfo requestInfo, String tenantId) {
+        MasterDetail masterDetail = MasterDetail.builder()
+                .name("IdPoolConfig")
+                .filter("[?(@.tenantId=='" + tenantId + "' && (@.isActive==true || @.isActive==null))]")
+                .build();
+
+        Map<String, List<MasterDetail>> masterDetails = new HashMap<>();
+        masterDetails.put("beneficiary-idgen", Collections.singletonList(masterDetail));
+
+        MdmsResponse mdmsResponse = getMasterData(requestInfo, tenantId, masterDetails);
+
+        if (mdmsResponse.getMdmsRes() == null
+                || !mdmsResponse.getMdmsRes().containsKey("beneficiary-idgen")
+                || !mdmsResponse.getMdmsRes().get("beneficiary-idgen").containsKey("IdPoolConfig")
+                || mdmsResponse.getMdmsRes().get("beneficiary-idgen").get("IdPoolConfig").isEmpty()
+                || mdmsResponse.getMdmsRes().get("beneficiary-idgen").get("IdPoolConfig").get(0) == null) {
+            log.debug("No id pool config found in MDMS for tenantId={}", tenantId);
+            return Optional.empty();
+        }
+
+        Map<String, Object> configData =
+                (Map<String, Object>) mdmsResponse.getMdmsRes().get("beneficiary-idgen").get("IdPoolConfig").get(0);
+        DocumentContext documentContext = JsonPath.parse(configData);
+
+        String seqCode = readStringField(documentContext, "seqCode", propertiesManager.getDefaultIdPoolConfig().getSeqCode());
+        int paddingLength = readIntField(documentContext, "paddingLength", propertiesManager.getDefaultIdPoolConfig().getPaddingLength());
+
+        return Optional.of(IdPoolConfig.builder()
+                .seqCode(seqCode)
+                .paddingLength(paddingLength)
+                .build());
+    }
+
+    private String readStringField(DocumentContext documentContext, String field, String defaultValue) {
+        try {
+            String value = documentContext.read("$." + field);
+            return value != null ? value : defaultValue;
+        } catch (Exception e) {
+            return defaultValue;
+        }
     }
 
     private boolean readBooleanField(DocumentContext documentContext, String field, boolean defaultValue) {

--- a/core-services/beneficiary-idgen/src/main/java/org/egov/id/service/MdmsService.java
+++ b/core-services/beneficiary-idgen/src/main/java/org/egov/id/service/MdmsService.java
@@ -103,27 +103,14 @@ public class MdmsService {
     public Optional<DispatchLimitConfig> getDispatchLimitConfig(RequestInfo requestInfo, String tenantId) {
         String module = propertiesManager.getMdmsDispatchLimitModule();
         String master = propertiesManager.getMdmsDispatchLimitMaster();
-
-        MasterDetail masterDetail = MasterDetail.builder()
-                .name(master)
-                .filter("[?(@.tenantId=='" + tenantId + "' && (@.isActive==true || @.isActive==null))]")
-                .build();
-
-        Map<String, List<MasterDetail>> masterDetails = new HashMap<>();
-        masterDetails.put(module, Collections.singletonList(masterDetail));
-
-        MdmsResponse mdmsResponse = getMasterData(requestInfo, tenantId, masterDetails);
-
-        if (mdmsResponse.getMdmsRes() == null
-                || !mdmsResponse.getMdmsRes().containsKey(module)
-                || !mdmsResponse.getMdmsRes().get(module).containsKey(master)
-                || mdmsResponse.getMdmsRes().get(module).get(master).isEmpty()
-                || mdmsResponse.getMdmsRes().get(module).get(master).get(0) == null) {
+        String filter = "[?(@.tenantId=='" + tenantId + "' && (@.isActive==true || @.isActive==null))]";
+        Optional<Map<String, Object>> configDataOpt = getFirstMdmsRecord(requestInfo, tenantId, module, master, filter);
+        if (configDataOpt.isEmpty()) {
             log.debug("No dispatch limit config found in MDMS for tenantId={}", tenantId);
             return Optional.empty();
         }
 
-        Map<String, Object> configData = (Map<String, Object>) mdmsResponse.getMdmsRes().get(module).get(master).get(0);
+        Map<String, Object> configData = configDataOpt.get();
         DocumentContext documentContext = JsonPath.parse(configData);
 
         boolean perDayEnabled = readBooleanField(documentContext, "perDayEnabled", propertiesManager.isDispatchLimitUserDevicePerDayEnabled());
@@ -144,27 +131,22 @@ public class MdmsService {
     }
 
     public Optional<IdPoolConfig> getIdPoolConfig(RequestInfo requestInfo, String tenantId) {
-        MasterDetail masterDetail = MasterDetail.builder()
-                .name("IdPoolConfig")
-                .filter("[?(@.tenantId=='" + tenantId + "' && (@.isActive==true || @.isActive==null))]")
-                .build();
-
-        Map<String, List<MasterDetail>> masterDetails = new HashMap<>();
-        masterDetails.put("beneficiary-idgen", Collections.singletonList(masterDetail));
-
-        MdmsResponse mdmsResponse = getMasterData(requestInfo, tenantId, masterDetails);
-
-        if (mdmsResponse.getMdmsRes() == null
-                || !mdmsResponse.getMdmsRes().containsKey("beneficiary-idgen")
-                || !mdmsResponse.getMdmsRes().get("beneficiary-idgen").containsKey("IdPoolConfig")
-                || mdmsResponse.getMdmsRes().get("beneficiary-idgen").get("IdPoolConfig").isEmpty()
-                || mdmsResponse.getMdmsRes().get("beneficiary-idgen").get("IdPoolConfig").get(0) == null) {
+        String module = propertiesManager.getMdmsIdPoolModule();
+        if (module == null || module.isBlank()) {
+            module = "beneficiary-idgen";
+        }
+        String master = propertiesManager.getMdmsIdPoolMaster();
+        if (master == null || master.isBlank()) {
+            master = "IdPoolConfig";
+        }
+        String filter = "[?(@.tenantId=='" + tenantId + "' && (@.isActive==true || @.isActive==null))]";
+        Optional<Map<String, Object>> configDataOpt = getFirstMdmsRecord(requestInfo, tenantId, module, master, filter);
+        if (configDataOpt.isEmpty()) {
             log.debug("No id pool config found in MDMS for tenantId={}", tenantId);
             return Optional.empty();
         }
 
-        Map<String, Object> configData =
-                (Map<String, Object>) mdmsResponse.getMdmsRes().get("beneficiary-idgen").get("IdPoolConfig").get(0);
+        Map<String, Object> configData = configDataOpt.get();
         DocumentContext documentContext = JsonPath.parse(configData);
 
         String seqCode = readStringField(documentContext, "seqCode", propertiesManager.getDefaultIdPoolConfig().getSeqCode());
@@ -174,6 +156,41 @@ public class MdmsService {
                 .seqCode(seqCode)
                 .paddingLength(paddingLength)
                 .build());
+    }
+
+    @SuppressWarnings("unchecked")
+    private Optional<Map<String, Object>> getFirstMdmsRecord(
+            RequestInfo requestInfo,
+            String tenantId,
+            String module,
+            String master,
+            String filter
+    ) {
+        MasterDetail masterDetail = MasterDetail.builder()
+                .name(master)
+                .filter(filter)
+                .build();
+
+        Map<String, List<MasterDetail>> masterDetails = new HashMap<>();
+        masterDetails.put(module, Collections.singletonList(masterDetail));
+
+        MdmsResponse mdmsResponse = getMasterData(requestInfo, tenantId, masterDetails);
+        if (mdmsResponse == null
+                || mdmsResponse.getMdmsRes() == null
+                || !mdmsResponse.getMdmsRes().containsKey(module)
+                || mdmsResponse.getMdmsRes().get(module) == null
+                || !mdmsResponse.getMdmsRes().get(module).containsKey(master)
+                || mdmsResponse.getMdmsRes().get(module).get(master) == null
+                || mdmsResponse.getMdmsRes().get(module).get(master).isEmpty()
+                || mdmsResponse.getMdmsRes().get(module).get(master).get(0) == null) {
+            return Optional.empty();
+        }
+
+        Object record = mdmsResponse.getMdmsRes().get(module).get(master).get(0);
+        if (!(record instanceof Map)) {
+            return Optional.empty();
+        }
+        return Optional.of((Map<String, Object>) record);
     }
 
     private String readStringField(DocumentContext documentContext, String field, String defaultValue) {

--- a/core-services/beneficiary-idgen/src/main/java/org/egov/id/service/RedissonIDService.java
+++ b/core-services/beneficiary-idgen/src/main/java/org/egov/id/service/RedissonIDService.java
@@ -1,7 +1,9 @@
 package org.egov.id.service;
 
 import lombok.extern.slf4j.Slf4j;
+import org.egov.common.contract.request.RequestInfo;
 import org.egov.id.config.PropertiesManager;
+import org.egov.id.model.DispatchLimitConfig;
 import org.egov.tracer.model.CustomException;
 import org.redisson.api.RAtomicLong;
 import org.redisson.api.RedissonClient;
@@ -25,10 +27,12 @@ public class RedissonIDService {
 
     private final RedissonClient redissonClient;
     private final PropertiesManager propertiesManager;
+    private final DispatchLimitCacheService dispatchLimitCacheService;
 
-    public RedissonIDService(RedissonClient redissonClient, PropertiesManager propertiesManager) {
+    public RedissonIDService(RedissonClient redissonClient, PropertiesManager propertiesManager, DispatchLimitCacheService dispatchLimitCacheService) {
         this.redissonClient = redissonClient;
         this.propertiesManager = propertiesManager;
+        this.dispatchLimitCacheService = dispatchLimitCacheService;
     }
 
     /**
@@ -68,15 +72,17 @@ public class RedissonIDService {
      * @return The remaining dispatch limit, either the total or the daily limit, depending on system configuration.
      * @throws CustomException If validation is enabled and the count is invalid or exceeds configured limits.
      */
-    public long getUserDeviceDispatchedIDRemaining(String tenantId, String userId, String deviceId, boolean validateCount, boolean allowToday) throws CustomException {
+    public long getUserDeviceDispatchedIDRemaining(String tenantId, String userId, String deviceId, boolean validateCount, boolean allowToday, RequestInfo requestInfo) throws CustomException {
         long totalCount = getUserDeviceDispatchedIDCountTotal(tenantId, userId, deviceId);
-        long remainingLimit = propertiesManager.getDispatchLimitUserDeviceTotal() - totalCount;
+        DispatchLimitConfig limitConfig = dispatchLimitCacheService.getEffectiveLimitConfig(tenantId, requestInfo);
+
+        long remainingLimit = limitConfig.getTotalLimit() - totalCount;
         if(validateCount && remainingLimit <= 0) {
             throw new CustomException("USER_DEVICE_LIMIT_EXCEEDED", "ID generation limit exceeded: Total limit for user: " + userId + " and device: " + deviceId + " exceeded. Remaining ids: " + remainingLimit + ". Please try again later.");
         }
-        if(allowToday && propertiesManager.isDispatchLimitUserDevicePerDayEnabled()) {
+        if(allowToday && limitConfig.isPerDayEnabled()) {
             long todayCount = getUserDeviceDispatchedIDCountToday(tenantId, userId, deviceId);
-            remainingLimit = Math.min(remainingLimit, propertiesManager.getDispatchLimitUserDevicePerDay() - todayCount);
+            remainingLimit = Math.min(remainingLimit, limitConfig.getPerDayLimit() - todayCount);
             if(validateCount && remainingLimit <= 0) {
                 throw new CustomException("USER_DEVICE_LIMIT_EXCEEDED", "ID generation limit exceeded: Daily limit for user: " + userId + " and device: " + deviceId + " exceeded. Remaining ids: " + (propertiesManager.getDispatchLimitUserDevicePerDay() - todayCount) + ". Please try again later.");
             }

--- a/core-services/beneficiary-idgen/src/main/java/org/egov/id/service/RedissonIDService.java
+++ b/core-services/beneficiary-idgen/src/main/java/org/egov/id/service/RedissonIDService.java
@@ -1,7 +1,6 @@
 package org.egov.id.service;
 
 import lombok.extern.slf4j.Slf4j;
-import org.egov.common.contract.request.RequestInfo;
 import org.egov.id.config.PropertiesManager;
 import org.egov.id.model.DispatchLimitConfig;
 import org.egov.tracer.model.CustomException;
@@ -27,12 +26,10 @@ public class RedissonIDService {
 
     private final RedissonClient redissonClient;
     private final PropertiesManager propertiesManager;
-    private final DispatchLimitCacheService dispatchLimitCacheService;
 
-    public RedissonIDService(RedissonClient redissonClient, PropertiesManager propertiesManager, DispatchLimitCacheService dispatchLimitCacheService) {
+    public RedissonIDService(RedissonClient redissonClient, PropertiesManager propertiesManager) {
         this.redissonClient = redissonClient;
         this.propertiesManager = propertiesManager;
-        this.dispatchLimitCacheService = dispatchLimitCacheService;
     }
 
     /**
@@ -72,9 +69,8 @@ public class RedissonIDService {
      * @return The remaining dispatch limit, either the total or the daily limit, depending on system configuration.
      * @throws CustomException If validation is enabled and the count is invalid or exceeds configured limits.
      */
-    public long getUserDeviceDispatchedIDRemaining(String tenantId, String userId, String deviceId, boolean validateCount, boolean allowToday, RequestInfo requestInfo) throws CustomException {
+    public long getUserDeviceDispatchedIDRemaining(String tenantId, String userId, String deviceId, boolean validateCount, boolean allowToday, DispatchLimitConfig limitConfig) throws CustomException {
         long totalCount = getUserDeviceDispatchedIDCountTotal(tenantId, userId, deviceId);
-        DispatchLimitConfig limitConfig = dispatchLimitCacheService.getEffectiveLimitConfig(tenantId, requestInfo);
 
         long remainingLimit = limitConfig.getTotalLimit() - totalCount;
         if(validateCount && remainingLimit <= 0) {
@@ -84,7 +80,7 @@ public class RedissonIDService {
             long todayCount = getUserDeviceDispatchedIDCountToday(tenantId, userId, deviceId);
             remainingLimit = Math.min(remainingLimit, limitConfig.getPerDayLimit() - todayCount);
             if(validateCount && remainingLimit <= 0) {
-                throw new CustomException("USER_DEVICE_LIMIT_EXCEEDED", "ID generation limit exceeded: Daily limit for user: " + userId + " and device: " + deviceId + " exceeded. Remaining ids: " + (propertiesManager.getDispatchLimitUserDevicePerDay() - todayCount) + ". Please try again later.");
+                throw new CustomException("USER_DEVICE_LIMIT_EXCEEDED", "ID generation limit exceeded: Daily limit for user: " + userId + " and device: " + deviceId + " exceeded. Remaining ids: " + (limitConfig.getPerDayLimit() - todayCount) + ". Please try again later.");
             }
             return remainingLimit;
         }
@@ -132,12 +128,12 @@ public class RedissonIDService {
      * @param increment a flag indicating whether to increment the count (true for increment, false for set/overwrite)
      * @param isToday a flag indicating whether the update is for today's count specifically
      */
-    public void updateUserDeviceDispatchedIDCount(String tenantId, String userId, String deviceId, long delta, boolean increment, boolean isToday) {
+    public void updateUserDeviceDispatchedIDCount(String tenantId, String userId, String deviceId, long delta, boolean increment, boolean isToday, DispatchLimitConfig limitConfig) {
         long totalDelta = delta;
         if (isToday) {
-            totalDelta = updateUserDeviceDispatchedIDCountForToday(tenantId,userId, deviceId, delta, increment);
+            totalDelta = updateUserDeviceDispatchedIDCountForToday(tenantId,userId, deviceId, delta, increment, limitConfig);
         }
-        updateUserDeviceDispatchedIDCountForTotal(tenantId, userId,deviceId, totalDelta, increment);
+        updateUserDeviceDispatchedIDCountForTotal(tenantId, userId,deviceId, totalDelta, increment, limitConfig);
     }
 
     /**
@@ -151,7 +147,7 @@ public class RedissonIDService {
      * @param delta the value to increment or set the total count
      * @param increment if true, the count will be incremented by delta; if false, the count will be set to delta
      */
-    private void updateUserDeviceDispatchedIDCountForTotal(String tenantId, String userId, String deviceId, long delta, boolean increment) {
+    private void updateUserDeviceDispatchedIDCountForTotal(String tenantId, String userId, String deviceId, long delta, boolean increment, DispatchLimitConfig limitConfig) {
         String totalKey = getUserDispatchedTotalCountKey(tenantId, userId, deviceId);
         RAtomicLong totalCounter = redissonClient.getAtomicLong(totalKey);
         if (increment) {
@@ -161,7 +157,7 @@ public class RedissonIDService {
             totalCounter.compareAndSet(totalCounter.get(), delta);
             log.debug("Updated total count to {} for user: {} and device: {}", delta, userId, deviceId);
         }
-        totalCounter.expire(Duration.ofDays(propertiesManager.getDispatchUsageUserDeviceTotalExpireDays()));
+        totalCounter.expire(Duration.ofDays(limitConfig.getTotalExpireDays()));
     }
 
     /**
@@ -175,7 +171,7 @@ public class RedissonIDService {
      * @param increment boolean flag indicating whether to increment (true) or overwrite (false) the count
      * @return the difference between the new value and the previous value of the dispatched count
      */
-    private long updateUserDeviceDispatchedIDCountForToday(String tenantId, String userId, String deviceId, long delta, boolean increment) {
+    private long updateUserDeviceDispatchedIDCountForToday(String tenantId, String userId, String deviceId, long delta, boolean increment, DispatchLimitConfig limitConfig) {
         String dailyKey = getUserDispatchedCountKey(tenantId, userId, deviceId, ZonedDateTime.now(ZoneId.of(propertiesManager.getUserTimeZone())).toLocalDate());
         RAtomicLong dailyCounter = redissonClient.getAtomicLong(dailyKey);
         long previousValue = dailyCounter.get();
@@ -188,7 +184,7 @@ public class RedissonIDService {
             dailyCounter.compareAndSet(previousValue, delta);
             log.debug("Updated daily count to {} for user: {} and device: {}", delta, userId, deviceId);
         }
-        dailyCounter.expire(Duration.ofDays(propertiesManager.getDispatchUsageUserDevicePerDayExpireDays()));
+        dailyCounter.expire(Duration.ofDays(limitConfig.getPerDayExpireDays()));
         return difference;
     }
 

--- a/core-services/beneficiary-idgen/src/main/resources/application.properties
+++ b/core-services/beneficiary-idgen/src/main/resources/application.properties
@@ -46,6 +46,9 @@ limit.id.user.device.per.day.expire.days=30
 limit.id.user.device.total.expire.days=30
 # restricts to today or overall while fetching already dispatched ids for distributors
 id.dispatch.retrieval.restrict-to-today.enabled=true
+mdms.dispatch.limit.module=beneficiary-idgen
+mdms.dispatch.limit.master=IdDispatchConfig
+dispatch.limit.cache.ttl.minutes=30
 id.validation.enabled=true
 id.pool.padding.length=12
 

--- a/core-services/beneficiary-idgen/src/main/resources/mdms/IdDispatchConfig.json
+++ b/core-services/beneficiary-idgen/src/main/resources/mdms/IdDispatchConfig.json
@@ -1,0 +1,20 @@
+{
+  "tenantId": "pb",
+  "moduleName": "beneficiary-idgen",
+  "IdDispatchConfig": [
+    {
+      "tenantId": "pb.amritsar",
+      "totalLimit": 500,
+      "perDayEnabled": true,
+      "perDayLimit": 50,
+      "isActive": true
+    },
+    {
+      "tenantId": "pb.ludhiana",
+      "totalLimit": 1000,
+      "perDayEnabled": false,
+      "perDayLimit": 100,
+      "isActive": true
+    }
+  ]
+}

--- a/core-services/beneficiary-idgen/src/main/resources/mdms/IdDispatchConfig.json
+++ b/core-services/beneficiary-idgen/src/main/resources/mdms/IdDispatchConfig.json
@@ -3,17 +3,13 @@
   "moduleName": "beneficiary-idgen",
   "IdDispatchConfig": [
     {
-      "tenantId": "pb.amritsar",
+      "tenantId": "pb",
       "totalLimit": 500,
       "perDayEnabled": true,
       "perDayLimit": 50,
-      "isActive": true
-    },
-    {
-      "tenantId": "pb.ludhiana",
-      "totalLimit": 1000,
-      "perDayEnabled": false,
-      "perDayLimit": 100,
+      "perDayExpireDays": 30,
+      "totalExpireDays": 30,
+      "restrictToTodayEnabled": true,
       "isActive": true
     }
   ]

--- a/core-services/beneficiary-idgen/src/main/resources/mdms/IdPoolConfig.json
+++ b/core-services/beneficiary-idgen/src/main/resources/mdms/IdPoolConfig.json
@@ -1,0 +1,13 @@
+{
+  "tenantId": "ch",
+  "moduleName": "beneficiary-idgen",
+  "IdPoolConfig": [
+    {
+      "tenantId": "ch",
+      "seqCode": "id.pool.number",
+      "paddingLength": 12,
+      "isActive": true
+    }
+  ]
+}
+

--- a/core-services/beneficiary-idgen/src/test/java/org/egov/id/service/DispatchLimitCacheServiceTest.java
+++ b/core-services/beneficiary-idgen/src/test/java/org/egov/id/service/DispatchLimitCacheServiceTest.java
@@ -1,5 +1,6 @@
 package org.egov.id.service;
 
+import com.github.benmanes.caffeine.cache.Ticker;
 import org.egov.common.contract.request.RequestInfo;
 import org.egov.id.config.PropertiesManager;
 import org.egov.id.model.DispatchLimitConfig;
@@ -9,11 +10,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.lang.reflect.Field;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -24,16 +27,22 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class DispatchLimitCacheServiceTest {
 
-    private static final String TENANT_ID = "pb.amritsar";
+    private static final String TENANT_ID = "ch";
     private static final DispatchLimitConfig DEFAULT_CONFIG = DispatchLimitConfig.builder()
             .perDayEnabled(true)
             .totalLimit(10000)
             .perDayLimit(100)
+            .perDayExpireDays(30)
+            .totalExpireDays(30)
+            .restrictToTodayEnabled(true)
             .build();
     private static final DispatchLimitConfig TENANT_CONFIG = DispatchLimitConfig.builder()
             .perDayEnabled(true)
             .totalLimit(500)
             .perDayLimit(50)
+            .perDayExpireDays(30)
+            .totalExpireDays(30)
+            .restrictToTodayEnabled(true)
             .build();
 
     @Mock
@@ -43,11 +52,13 @@ class DispatchLimitCacheServiceTest {
     private MdmsService mdmsService;
 
     private DispatchLimitCacheService dispatchLimitCacheService;
+    private ManualTicker ticker;
 
     @BeforeEach
     void setUp() {
         when(propertiesManager.getDispatchLimitCacheTtlMinutes()).thenReturn(30);
-        dispatchLimitCacheService = new DispatchLimitCacheService(propertiesManager, mdmsService);
+        ticker = new ManualTicker();
+        dispatchLimitCacheService = new DispatchLimitCacheService(propertiesManager, mdmsService, ticker);
     }
 
     @Test
@@ -97,10 +108,13 @@ class DispatchLimitCacheServiceTest {
                         .perDayEnabled(false)
                         .totalLimit(800)
                         .perDayLimit(80)
+                        .perDayExpireDays(30)
+                        .totalExpireDays(30)
+                        .restrictToTodayEnabled(true)
                         .build()));
 
         dispatchLimitCacheService.getEffectiveLimitConfig(TENANT_ID, new RequestInfo());
-        invalidateCache(TENANT_ID);
+        advanceBeyondTtl();
 
         DispatchLimitConfig result = dispatchLimitCacheService.getEffectiveLimitConfig(TENANT_ID, new RequestInfo());
 
@@ -126,28 +140,25 @@ class DispatchLimitCacheServiceTest {
                 .thenThrow(new RuntimeException("MDMS unavailable"));
 
         dispatchLimitCacheService.getEffectiveLimitConfig(TENANT_ID, new RequestInfo());
-        invalidateCache(TENANT_ID);
+        advanceBeyondTtl();
 
-        DispatchLimitConfig result = dispatchLimitCacheService.getEffectiveLimitConfig(TENANT_ID, new RequestInfo());
-
-        assertEquals(TENANT_CONFIG, result);
+        assertThrows(RuntimeException.class,
+                () -> dispatchLimitCacheService.getEffectiveLimitConfig(TENANT_ID, new RequestInfo()));
         verify(mdmsService, times(2)).getDispatchLimitConfig(any(), eq(TENANT_ID));
     }
 
     @Test
     void usesDefaultWhenMdmsFailsAndNoStaleConfigExists() {
-        when(propertiesManager.getDefaultDispatchLimitConfig()).thenReturn(DEFAULT_CONFIG);
         when(mdmsService.getDispatchLimitConfig(any(), eq(TENANT_ID)))
                 .thenThrow(new RuntimeException("MDMS unavailable"));
 
-        DispatchLimitConfig result = dispatchLimitCacheService.getEffectiveLimitConfig(TENANT_ID, new RequestInfo());
-
-        assertEquals(DEFAULT_CONFIG, result);
+        assertThrows(RuntimeException.class,
+                () -> dispatchLimitCacheService.getEffectiveLimitConfig(TENANT_ID, new RequestInfo()));
     }
 
     @Test
     void normalizesTenantIdToLowercase() {
-        when(mdmsService.getDispatchLimitConfig(any(), eq(TENANT_ID))).thenReturn(Optional.of(TENANT_CONFIG));
+        when(mdmsService.getDispatchLimitConfig(any(), any())).thenReturn(Optional.of(TENANT_CONFIG));
 
         DispatchLimitConfig result = dispatchLimitCacheService.getEffectiveLimitConfig("PB.Amritsar", new RequestInfo());
 
@@ -156,11 +167,20 @@ class DispatchLimitCacheServiceTest {
         assertEquals(50, result.getPerDayLimit());
     }
 
-    private void invalidateCache(String tenantId) throws Exception {
-        Field cacheField = DispatchLimitCacheService.class.getDeclaredField("cache");
-        cacheField.setAccessible(true);
-        com.github.benmanes.caffeine.cache.Cache<String, DispatchLimitConfig> cache =
-                (com.github.benmanes.caffeine.cache.Cache<String, DispatchLimitConfig>) cacheField.get(dispatchLimitCacheService);
-        cache.invalidate(tenantId.toLowerCase());
+    private void advanceBeyondTtl() {
+        ticker.advance(31, TimeUnit.MINUTES);
+    }
+
+    private static final class ManualTicker implements Ticker {
+        private final AtomicLong nanos = new AtomicLong();
+
+        @Override
+        public long read() {
+            return nanos.get();
+        }
+
+        void advance(long time, TimeUnit unit) {
+            nanos.addAndGet(unit.toNanos(time));
+        }
     }
 }

--- a/core-services/beneficiary-idgen/src/test/java/org/egov/id/service/DispatchLimitCacheServiceTest.java
+++ b/core-services/beneficiary-idgen/src/test/java/org/egov/id/service/DispatchLimitCacheServiceTest.java
@@ -1,0 +1,166 @@
+package org.egov.id.service;
+
+import org.egov.common.contract.request.RequestInfo;
+import org.egov.id.config.PropertiesManager;
+import org.egov.id.model.DispatchLimitConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Field;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DispatchLimitCacheServiceTest {
+
+    private static final String TENANT_ID = "pb.amritsar";
+    private static final DispatchLimitConfig DEFAULT_CONFIG = DispatchLimitConfig.builder()
+            .perDayEnabled(true)
+            .totalLimit(10000)
+            .perDayLimit(100)
+            .build();
+    private static final DispatchLimitConfig TENANT_CONFIG = DispatchLimitConfig.builder()
+            .perDayEnabled(true)
+            .totalLimit(500)
+            .perDayLimit(50)
+            .build();
+
+    @Mock
+    private PropertiesManager propertiesManager;
+
+    @Mock
+    private MdmsService mdmsService;
+
+    private DispatchLimitCacheService dispatchLimitCacheService;
+
+    @BeforeEach
+    void setUp() {
+        when(propertiesManager.getDispatchLimitCacheTtlMinutes()).thenReturn(30);
+        dispatchLimitCacheService = new DispatchLimitCacheService(propertiesManager, mdmsService);
+    }
+
+    @Test
+    void returnsDefaultConfigWhenTenantIdAbsent() {
+        when(propertiesManager.getDefaultDispatchLimitConfig()).thenReturn(DEFAULT_CONFIG);
+        DispatchLimitConfig result = dispatchLimitCacheService.getEffectiveLimitConfig(null, new RequestInfo());
+
+        assertEquals(DEFAULT_CONFIG, result);
+        verify(mdmsService, times(0)).getDispatchLimitConfig(any(), any());
+    }
+
+    @Test
+    void returnsDefaultConfigWhenTenantIdBlank() {
+        when(propertiesManager.getDefaultDispatchLimitConfig()).thenReturn(DEFAULT_CONFIG);
+        DispatchLimitConfig result = dispatchLimitCacheService.getEffectiveLimitConfig("  ", new RequestInfo());
+
+        assertEquals(DEFAULT_CONFIG, result);
+        verify(mdmsService, times(0)).getDispatchLimitConfig(any(), any());
+    }
+
+    @Test
+    void loadsFromMdmsOnFirstRequestForTenant() {
+        when(mdmsService.getDispatchLimitConfig(any(), eq(TENANT_ID))).thenReturn(Optional.of(TENANT_CONFIG));
+
+        DispatchLimitConfig result = dispatchLimitCacheService.getEffectiveLimitConfig(TENANT_ID, new RequestInfo());
+
+        assertEquals(TENANT_CONFIG, result);
+        verify(mdmsService, times(1)).getDispatchLimitConfig(any(), eq(TENANT_ID));
+    }
+
+    @Test
+    void usesCacheOnSubsequentRequestsWithinTtl() {
+        when(mdmsService.getDispatchLimitConfig(any(), eq(TENANT_ID))).thenReturn(Optional.of(TENANT_CONFIG));
+
+        dispatchLimitCacheService.getEffectiveLimitConfig(TENANT_ID, new RequestInfo());
+        DispatchLimitConfig result = dispatchLimitCacheService.getEffectiveLimitConfig(TENANT_ID, new RequestInfo());
+
+        assertEquals(TENANT_CONFIG, result);
+        verify(mdmsService, times(1)).getDispatchLimitConfig(any(), eq(TENANT_ID));
+    }
+
+    @Test
+    void refreshesFromMdmsAfterCacheExpiry() throws Exception {
+        when(mdmsService.getDispatchLimitConfig(any(), eq(TENANT_ID)))
+                .thenReturn(Optional.of(TENANT_CONFIG))
+                .thenReturn(Optional.of(DispatchLimitConfig.builder()
+                        .perDayEnabled(false)
+                        .totalLimit(800)
+                        .perDayLimit(80)
+                        .build()));
+
+        dispatchLimitCacheService.getEffectiveLimitConfig(TENANT_ID, new RequestInfo());
+        invalidateCache(TENANT_ID);
+
+        DispatchLimitConfig result = dispatchLimitCacheService.getEffectiveLimitConfig(TENANT_ID, new RequestInfo());
+
+        assertFalse(result.isPerDayEnabled());
+        assertEquals(800, result.getTotalLimit());
+        verify(mdmsService, times(2)).getDispatchLimitConfig(any(), eq(TENANT_ID));
+    }
+
+    @Test
+    void fallsBackToDefaultWhenMdmsHasNoConfig() {
+        when(propertiesManager.getDefaultDispatchLimitConfig()).thenReturn(DEFAULT_CONFIG);
+        when(mdmsService.getDispatchLimitConfig(any(), eq(TENANT_ID))).thenReturn(Optional.empty());
+
+        DispatchLimitConfig result = dispatchLimitCacheService.getEffectiveLimitConfig(TENANT_ID, new RequestInfo());
+
+        assertEquals(DEFAULT_CONFIG, result);
+    }
+
+    @Test
+    void usesStaleConfigWhenMdmsFailsAfterPreviousSuccessfulLoad() throws Exception {
+        when(mdmsService.getDispatchLimitConfig(any(), eq(TENANT_ID)))
+                .thenReturn(Optional.of(TENANT_CONFIG))
+                .thenThrow(new RuntimeException("MDMS unavailable"));
+
+        dispatchLimitCacheService.getEffectiveLimitConfig(TENANT_ID, new RequestInfo());
+        invalidateCache(TENANT_ID);
+
+        DispatchLimitConfig result = dispatchLimitCacheService.getEffectiveLimitConfig(TENANT_ID, new RequestInfo());
+
+        assertEquals(TENANT_CONFIG, result);
+        verify(mdmsService, times(2)).getDispatchLimitConfig(any(), eq(TENANT_ID));
+    }
+
+    @Test
+    void usesDefaultWhenMdmsFailsAndNoStaleConfigExists() {
+        when(propertiesManager.getDefaultDispatchLimitConfig()).thenReturn(DEFAULT_CONFIG);
+        when(mdmsService.getDispatchLimitConfig(any(), eq(TENANT_ID)))
+                .thenThrow(new RuntimeException("MDMS unavailable"));
+
+        DispatchLimitConfig result = dispatchLimitCacheService.getEffectiveLimitConfig(TENANT_ID, new RequestInfo());
+
+        assertEquals(DEFAULT_CONFIG, result);
+    }
+
+    @Test
+    void normalizesTenantIdToLowercase() {
+        when(mdmsService.getDispatchLimitConfig(any(), eq(TENANT_ID))).thenReturn(Optional.of(TENANT_CONFIG));
+
+        DispatchLimitConfig result = dispatchLimitCacheService.getEffectiveLimitConfig("PB.Amritsar", new RequestInfo());
+
+        assertEquals(TENANT_CONFIG, result);
+        assertTrue(result.isPerDayEnabled());
+        assertEquals(50, result.getPerDayLimit());
+    }
+
+    private void invalidateCache(String tenantId) throws Exception {
+        Field cacheField = DispatchLimitCacheService.class.getDeclaredField("cache");
+        cacheField.setAccessible(true);
+        com.github.benmanes.caffeine.cache.Cache<String, DispatchLimitConfig> cache =
+                (com.github.benmanes.caffeine.cache.Cache<String, DispatchLimitConfig>) cacheField.get(dispatchLimitCacheService);
+        cache.invalidate(tenantId.toLowerCase());
+    }
+}

--- a/core-services/beneficiary-idgen/src/test/java/org/egov/id/service/DispatchLimitCacheServiceTest.java
+++ b/core-services/beneficiary-idgen/src/test/java/org/egov/id/service/DispatchLimitCacheServiceTest.java
@@ -16,8 +16,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
@@ -142,29 +140,52 @@ class DispatchLimitCacheServiceTest {
         dispatchLimitCacheService.getEffectiveLimitConfig(TENANT_ID, new RequestInfo());
         advanceBeyondTtl();
 
-        assertThrows(RuntimeException.class,
-                () -> dispatchLimitCacheService.getEffectiveLimitConfig(TENANT_ID, new RequestInfo()));
+        DispatchLimitConfig result = dispatchLimitCacheService.getEffectiveLimitConfig(TENANT_ID, new RequestInfo());
+
+        assertEquals(TENANT_CONFIG, result);
         verify(mdmsService, times(2)).getDispatchLimitConfig(any(), eq(TENANT_ID));
     }
 
     @Test
     void usesDefaultWhenMdmsFailsAndNoStaleConfigExists() {
+        when(propertiesManager.getDefaultDispatchLimitConfig()).thenReturn(DEFAULT_CONFIG);
         when(mdmsService.getDispatchLimitConfig(any(), eq(TENANT_ID)))
                 .thenThrow(new RuntimeException("MDMS unavailable"));
 
-        assertThrows(RuntimeException.class,
-                () -> dispatchLimitCacheService.getEffectiveLimitConfig(TENANT_ID, new RequestInfo()));
+        DispatchLimitConfig result = dispatchLimitCacheService.getEffectiveLimitConfig(TENANT_ID, new RequestInfo());
+
+        assertEquals(DEFAULT_CONFIG, result);
     }
 
     @Test
-    void normalizesTenantIdToLowercase() {
-        when(mdmsService.getDispatchLimitConfig(any(), any())).thenReturn(Optional.of(TENANT_CONFIG));
+    void retriesMdmsOnNextRequestWhenColdLoadFailsInsteadOfCachingFallback() {
+        when(propertiesManager.getDefaultDispatchLimitConfig()).thenReturn(DEFAULT_CONFIG);
+        when(mdmsService.getDispatchLimitConfig(any(), eq(TENANT_ID)))
+                .thenThrow(new RuntimeException("MDMS unavailable"))
+                .thenReturn(Optional.of(TENANT_CONFIG));
 
-        DispatchLimitConfig result = dispatchLimitCacheService.getEffectiveLimitConfig("PB.Amritsar", new RequestInfo());
+        // Cold failure with no prior config: the default is served but must NOT be pinned in the cache.
+        assertEquals(DEFAULT_CONFIG, dispatchLimitCacheService.getEffectiveLimitConfig(TENANT_ID, new RequestInfo()));
+
+        // Still within the TTL window: because the failure was not cached, the next request retries
+        // MDMS (now recovered) and serves the real tenant config.
+        assertEquals(TENANT_CONFIG, dispatchLimitCacheService.getEffectiveLimitConfig(TENANT_ID, new RequestInfo()));
+
+        // The recovered config is now cached, so a third request within the TTL does not hit MDMS again.
+        assertEquals(TENANT_CONFIG, dispatchLimitCacheService.getEffectiveLimitConfig(TENANT_ID, new RequestInfo()));
+        verify(mdmsService, times(2)).getDispatchLimitConfig(any(), eq(TENANT_ID));
+    }
+
+    @Test
+    void usesRawTenantIdAsKeyWithoutNormalization() {
+        String tenantId = "PB.Amritsar";
+        when(mdmsService.getDispatchLimitConfig(any(), eq(tenantId))).thenReturn(Optional.of(TENANT_CONFIG));
+
+        DispatchLimitConfig result = dispatchLimitCacheService.getEffectiveLimitConfig(tenantId, new RequestInfo());
 
         assertEquals(TENANT_CONFIG, result);
-        assertTrue(result.isPerDayEnabled());
-        assertEquals(50, result.getPerDayLimit());
+        // The tenantId is used verbatim as the MDMS lookup key and cache key; no case normalization is applied.
+        verify(mdmsService).getDispatchLimitConfig(any(), eq(tenantId));
     }
 
     private void advanceBeyondTtl() {

--- a/core-services/beneficiary-idgen/src/test/java/org/egov/id/service/IdGenerationServiceTest.java
+++ b/core-services/beneficiary-idgen/src/test/java/org/egov/id/service/IdGenerationServiceTest.java
@@ -161,6 +161,46 @@ class IdGenerationServiceTest {
     }
 
     @Test
+    @SuppressWarnings("unchecked")
+    void asyncPoolFallsBackToDefaultConfigWhenMdmsHasNoPoolConfig() {
+        // When MDMS returns no IdPoolConfig for the tenant, handleAsyncIdPoolRequest must fall back to
+        // propertiesManager.getDefaultIdPoolConfig() (see the orElseGet in the production path) and generate
+        // using that configuration. Set the singleton default to a DIFFERENT width (12) so observing width 8
+        // in the output proves the fallback IdPoolConfig's own width was threaded through.
+        ReflectionTestUtils.setField(idGenerationService, "defaultPaddingLength", 12);
+        ReflectionTestUtils.setField(idGenerationService, "MAX_RECORDS_PER_PERSIST_BATCH", 1000);
+        ReflectionTestUtils.setField(idGenerationService, "idFormatFromMDMS", false);
+
+        String tenantId = "ch";
+        when(mdmsService.getIdPoolConfig(any(), eq(tenantId))).thenReturn(Optional.empty());
+        IdPoolConfig fallbackConfig = IdPoolConfig.builder().seqCode("SEQ_DEFAULT").paddingLength(8).build();
+        when(propertiesManager.getDefaultIdPoolConfig()).thenReturn(fallbackConfig);
+        // idFormatFromMDMS=false, so the format is resolved from the DB using the fallback seqCode.
+        when(jdbcTemplate.queryForObject(anyString(), eq(String.class), any(), any())).thenReturn("[SEQ_DEFAULT]");
+        // NEXTVAL block the [SEQ_DEFAULT] token resolves to.
+        when(jdbcTemplate.queryForList(anyString(), any(Object[].class), eq(String.class)))
+                .thenReturn(Collections.singletonList("7"));
+        when(propertiesManager.getSaveIdPoolTopic()).thenReturn("save-in-id-pool");
+
+        IDPoolGenerationKafkaRequest request = IDPoolGenerationKafkaRequest.builder()
+                .tenantId(tenantId)
+                .chunkSize(1)
+                .requestInfo(requestInfoWithUser())
+                .build();
+
+        idGenerationService.handleAsyncIdPoolRequest(request);
+
+        ArgumentCaptor<Object> payloadCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(idGenProducer).push(eq("save-in-id-pool"), payloadCaptor.capture());
+
+        Map<String, Object> payload = (Map<String, Object>) payloadCaptor.getValue();
+        List<IdRecord> records = (List<IdRecord>) payload.get("idPool");
+        assertEquals(1, records.size());
+        // Width 8 (from the fallback default IdPoolConfig), NOT 12 (the singleton default padding).
+        assertEquals("00000007", records.get(0).getId());
+    }
+
+    @Test
     void asyncPoolAbortsWithoutPublishingWhenSeqCodeMissing() {
         // Issue #5: a blank seqCode must be detected as a configuration error and abort generation, rather
         // than silently producing IDs from an unintended sequence. fetchIdFormat throws CONFIGURATION_ERROR;

--- a/core-services/beneficiary-idgen/src/test/java/org/egov/id/service/IdGenerationServiceTest.java
+++ b/core-services/beneficiary-idgen/src/test/java/org/egov/id/service/IdGenerationServiceTest.java
@@ -1,21 +1,38 @@
 package org.egov.id.service;
 
 import org.egov.common.contract.request.RequestInfo;
+import org.egov.common.contract.request.User;
 import org.egov.common.models.idgen.*;
-import org.egov.id.repository.IdRepository;
+import org.egov.id.config.PropertiesManager;
+import org.egov.id.model.IdPoolConfig;
+import org.egov.id.producer.IdGenProducer;
 import org.egov.tracer.model.CustomException;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Stream;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class IdGenerationServiceTest {
@@ -24,7 +41,16 @@ class IdGenerationServiceTest {
     private IdGenerationService idGenerationService;
 
     @Mock
-    private IdRepository idRepository;
+    private JdbcTemplate jdbcTemplate;
+
+    @Mock
+    private MdmsService mdmsService;
+
+    @Mock
+    private IdGenProducer idGenProducer;
+
+    @Mock
+    private PropertiesManager propertiesManager;
 
     @ParameterizedTest
     @MethodSource("invalidRequests")
@@ -62,6 +88,107 @@ class IdGenerationServiceTest {
         req.setIdRequests(idRequests);
         req.setRequestInfo(requestInfo);
         return req;
+    }
+
+    @Test
+    void zeroPadsSequenceToConfiguredDefaultWidth() {
+        ReflectionTestUtils.setField(idGenerationService, "defaultPaddingLength", 12);
+        // NEXTVAL result the [seq...] token resolves to; format is preset so no MDMS/DB format lookup runs.
+        when(jdbcTemplate.queryForList(anyString(), any(Object[].class), eq(String.class)))
+                .thenReturn(Collections.singletonList("42"));
+
+        IdGenerationRequest request = request(
+                Collections.singletonList(buildRequest(null, "ch", "[SEQ_EG]", 1)), new RequestInfo());
+
+        IdGenerationResponse response = assertDoesNotThrow(() -> idGenerationService.generateIdResponse(request));
+
+        assertEquals("000000000042", response.getIdResponses().get(0).getId());
+    }
+
+    @Test
+    void emitsUnpaddedSequenceWhenPaddingLengthNonPositive() {
+        // A non-positive width must not produce the invalid "%00d" spec that throws at runtime; it
+        // simply yields the raw sequence number.
+        ReflectionTestUtils.setField(idGenerationService, "defaultPaddingLength", 0);
+        when(jdbcTemplate.queryForList(anyString(), any(Object[].class), eq(String.class)))
+                .thenReturn(Collections.singletonList("42"));
+
+        IdGenerationRequest request = request(
+                Collections.singletonList(buildRequest(null, "ch", "[SEQ_EG]", 1)), new RequestInfo());
+
+        IdGenerationResponse response = assertDoesNotThrow(() -> idGenerationService.generateIdResponse(request));
+
+        assertEquals("42", response.getIdResponses().get(0).getId());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void asyncPoolPathUsesTenantPaddingWidthNotSingletonDefault() {
+        // Core guarantee of the Issue #1 fix: the async pool path must pad with the tenant's own
+        // IdPoolConfig width, never with the shared-singleton default. Set the singleton default to a
+        // DIFFERENT width (12) so that observing width 6 in the output proves the per-tenant value was
+        // threaded through rather than read from shared state.
+        ReflectionTestUtils.setField(idGenerationService, "defaultPaddingLength", 12);
+        ReflectionTestUtils.setField(idGenerationService, "MAX_RECORDS_PER_PERSIST_BATCH", 1000);
+        ReflectionTestUtils.setField(idGenerationService, "idFormatFromMDMS", false);
+
+        String tenantId = "ch";
+        IdPoolConfig tenantPoolConfig = IdPoolConfig.builder().seqCode("SEQ_TEST").paddingLength(6).build();
+        when(mdmsService.getIdPoolConfig(any(), eq(tenantId))).thenReturn(Optional.of(tenantPoolConfig));
+        // idFormatFromMDMS=false, so the format is resolved from the DB.
+        when(jdbcTemplate.queryForObject(anyString(), eq(String.class), any(), any())).thenReturn("[SEQ_TEST]");
+        // NEXTVAL block the [SEQ_TEST] token resolves to.
+        when(jdbcTemplate.queryForList(anyString(), any(Object[].class), eq(String.class)))
+                .thenReturn(Collections.singletonList("42"));
+        when(propertiesManager.getSaveIdPoolTopic()).thenReturn("save-in-id-pool");
+
+        IDPoolGenerationKafkaRequest request = IDPoolGenerationKafkaRequest.builder()
+                .tenantId(tenantId)
+                .chunkSize(1)
+                .requestInfo(requestInfoWithUser())
+                .build();
+
+        idGenerationService.handleAsyncIdPoolRequest(request);
+
+        ArgumentCaptor<Object> payloadCaptor = ArgumentCaptor.forClass(Object.class);
+        verify(idGenProducer).push(eq("save-in-id-pool"), payloadCaptor.capture());
+
+        Map<String, Object> payload = (Map<String, Object>) payloadCaptor.getValue();
+        List<IdRecord> records = (List<IdRecord>) payload.get("idPool");
+        assertEquals(1, records.size());
+        // Width 6 (from the tenant IdPoolConfig), NOT 12 (the singleton default).
+        assertEquals("000042", records.get(0).getId());
+    }
+
+    @Test
+    void asyncPoolAbortsWithoutPublishingWhenSeqCodeMissing() {
+        // Issue #5: a blank seqCode must be detected as a configuration error and abort generation, rather
+        // than silently producing IDs from an unintended sequence. fetchIdFormat throws CONFIGURATION_ERROR;
+        // the async handler swallows that non-retryable error, so the observable guarantee is that NO
+        // sequence is queried and NOTHING is published.
+        ReflectionTestUtils.setField(idGenerationService, "MAX_RECORDS_PER_PERSIST_BATCH", 1000);
+
+        String tenantId = "ch";
+        IdPoolConfig misconfigured = IdPoolConfig.builder().seqCode("").paddingLength(12).build();
+        when(mdmsService.getIdPoolConfig(any(), eq(tenantId))).thenReturn(Optional.of(misconfigured));
+
+        IDPoolGenerationKafkaRequest request = IDPoolGenerationKafkaRequest.builder()
+                .tenantId(tenantId)
+                .chunkSize(1)
+                .requestInfo(requestInfoWithUser())
+                .build();
+
+        assertDoesNotThrow(() -> idGenerationService.handleAsyncIdPoolRequest(request));
+
+        // seqCode was blank, so generation aborts before any DB lookup or Kafka publish.
+        verifyNoInteractions(jdbcTemplate);
+        verifyNoInteractions(idGenProducer);
+    }
+
+    private static RequestInfo requestInfoWithUser() {
+        RequestInfo requestInfo = new RequestInfo();
+        requestInfo.setUserInfo(User.builder().uuid("test-uuid").build());
+        return requestInfo;
     }
 
 }

--- a/core-services/beneficiary-idgen/src/test/java/org/egov/id/service/MdmsServiceTest.java
+++ b/core-services/beneficiary-idgen/src/test/java/org/egov/id/service/MdmsServiceTest.java
@@ -14,10 +14,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import net.minidev.json.JSONArray;
 
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -180,6 +183,58 @@ class MdmsServiceTest {
         assertThrows(CustomException.class, () -> this.mdmsService.getIdFormat(requestInfo, new IdRequest()));
         verify(this.mdmsClientService).getMaster((org.egov.common.contract.request.RequestInfo) any(), (String) any(),
                 (java.util.Map<String, java.util.List<org.egov.mdms.model.MasterDetail>>) any());
+    }
+
+    @Test
+    void testGetDispatchLimitConfigReturnsEmptyWhenNoData() {
+        when(propertiesManager.getMdmsDispatchLimitModule()).thenReturn("beneficiary-idgen");
+        when(propertiesManager.getMdmsDispatchLimitMaster()).thenReturn("IdDispatchConfig");
+        when(this.mdmsClientService.getMaster(any(), any(), any())).thenReturn(new MdmsResponse(new ResponseInfo(), new HashMap<>()));
+
+        Optional<?> result = this.mdmsService.getDispatchLimitConfig(new RequestInfo(), "ch");
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void testGetDispatchLimitConfigParsesDataAndAppliesDefaults() {
+        when(propertiesManager.getMdmsDispatchLimitModule()).thenReturn("beneficiary-idgen");
+        when(propertiesManager.getMdmsDispatchLimitMaster()).thenReturn("IdDispatchConfig");
+        when(propertiesManager.isDispatchLimitUserDevicePerDayEnabled()).thenReturn(true);
+        when(propertiesManager.getDispatchLimitUserDeviceTotal()).thenReturn(10000);
+        when(propertiesManager.getDispatchLimitUserDevicePerDay()).thenReturn(100);
+        when(propertiesManager.getDispatchUsageUserDevicePerDayExpireDays()).thenReturn(30);
+        when(propertiesManager.getDispatchUsageUserDeviceTotalExpireDays()).thenReturn(30);
+        when(propertiesManager.isIdDispatchRetrievalRestrictToTodayEnabled()).thenReturn(true);
+
+        Map<String, Object> config = new HashMap<>();
+        config.put("tenantId", "ch");
+        config.put("totalLimit", 500);
+        config.put("perDayEnabled", false);
+        config.put("perDayLimit", 50);
+        config.put("perDayExpireDays", 20);
+        config.put("totalExpireDays", 40);
+        config.put("restrictToTodayEnabled", false);
+
+        JSONArray masterList = new JSONArray();
+        masterList.add(config);
+        Map<String, JSONArray> moduleMap = new HashMap<>();
+        moduleMap.put("IdDispatchConfig", masterList);
+        Map<String, Map<String, JSONArray>> mdmsRes = new HashMap<>();
+        mdmsRes.put("beneficiary-idgen", moduleMap);
+
+        when(this.mdmsClientService.getMaster(any(), any(), any()))
+                .thenReturn(new MdmsResponse(new ResponseInfo(), (Map) mdmsRes));
+
+        Optional<org.egov.id.model.DispatchLimitConfig> result = this.mdmsService.getDispatchLimitConfig(new RequestInfo(), "ch");
+
+        assertTrue(result.isPresent());
+        assertEquals(500, result.get().getTotalLimit());
+        assertFalse(result.get().isPerDayEnabled());
+        assertEquals(50, result.get().getPerDayLimit());
+        assertEquals(20, result.get().getPerDayExpireDays());
+        assertEquals(40, result.get().getTotalExpireDays());
+        assertFalse(result.get().isRestrictToTodayEnabled());
     }
 }
 

--- a/core-services/beneficiary-idgen/src/test/java/org/egov/id/service/MdmsServiceTest.java
+++ b/core-services/beneficiary-idgen/src/test/java/org/egov/id/service/MdmsServiceTest.java
@@ -3,6 +3,7 @@ package org.egov.id.service;
 import org.egov.common.contract.request.RequestInfo;
 import org.egov.common.contract.response.ResponseInfo;
 import org.egov.common.models.idgen.IdRequest;
+import org.egov.id.config.PropertiesManager;
 import org.egov.mdms.model.MasterDetail;
 import org.egov.mdms.model.MdmsResponse;
 import org.egov.mdms.service.MdmsClientService;
@@ -26,6 +27,9 @@ import static org.mockito.Mockito.*;
 class MdmsServiceTest {
     @MockBean
     private MdmsClientService mdmsClientService;
+
+    @MockBean
+    private PropertiesManager propertiesManager;
 
     @Autowired
     private MdmsService mdmsService;

--- a/core-services/beneficiary-idgen/src/test/java/org/egov/id/service/MdmsServiceTest.java
+++ b/core-services/beneficiary-idgen/src/test/java/org/egov/id/service/MdmsServiceTest.java
@@ -275,5 +275,59 @@ class MdmsServiceTest {
 
         assertTrue(result.isEmpty());
     }
+
+    @Test
+    void testGetIdPoolConfigPropagatesExceptionWhenMdmsThrows() {
+        when(propertiesManager.getMdmsIdPoolModule()).thenReturn("beneficiary-idgen");
+        when(propertiesManager.getMdmsIdPoolMaster()).thenReturn("IdPoolConfig");
+        when(this.mdmsClientService.getMaster(any(), any(), any()))
+                .thenThrow(new RuntimeException("MDMS service unavailable"));
+
+        RuntimeException thrown = assertThrows(RuntimeException.class,
+                () -> this.mdmsService.getIdPoolConfig(new RequestInfo(), "ch"));
+
+        assertEquals("MDMS service unavailable", thrown.getMessage());
+        verify(this.mdmsClientService).getMaster(any(), any(), any());
+    }
+
+    @Test
+    void testGetIdPoolConfigThrowsCustomExceptionWhenMdmsThrowsCustomException() {
+        when(propertiesManager.getMdmsIdPoolModule()).thenReturn("beneficiary-idgen");
+        when(propertiesManager.getMdmsIdPoolMaster()).thenReturn("IdPoolConfig");
+        when(this.mdmsClientService.getMaster(any(), any(), any()))
+                .thenThrow(new CustomException("MDMS_ERROR", "Connection refused"));
+
+        CustomException thrown = assertThrows(CustomException.class,
+                () -> this.mdmsService.getIdPoolConfig(new RequestInfo(), "ch"));
+
+        assertEquals("MDMS_ERROR", thrown.getCode());
+    }
+
+    @Test
+    void testGetIdPoolConfigThrowsWhenTenantIdIsNull() {
+        CustomException thrown = assertThrows(CustomException.class,
+                () -> this.mdmsService.getIdPoolConfig(new RequestInfo(), null));
+
+        assertEquals("INVALID_TENANT_ID", thrown.getCode());
+        verifyNoInteractions(this.mdmsClientService);
+    }
+
+    @Test
+    void testGetIdPoolConfigThrowsWhenTenantIdIsBlank() {
+        CustomException thrown = assertThrows(CustomException.class,
+                () -> this.mdmsService.getIdPoolConfig(new RequestInfo(), "   "));
+
+        assertEquals("INVALID_TENANT_ID", thrown.getCode());
+        verifyNoInteractions(this.mdmsClientService);
+    }
+
+    @Test
+    void testGetIdPoolConfigThrowsWhenTenantIdContainsUnsafeCharacters() {
+        CustomException thrown = assertThrows(CustomException.class,
+                () -> this.mdmsService.getIdPoolConfig(new RequestInfo(), "ch' || true || '"));
+
+        assertEquals("INVALID_TENANT_ID", thrown.getCode());
+        verifyNoInteractions(this.mdmsClientService);
+    }
 }
 

--- a/core-services/beneficiary-idgen/src/test/java/org/egov/id/service/MdmsServiceTest.java
+++ b/core-services/beneficiary-idgen/src/test/java/org/egov/id/service/MdmsServiceTest.java
@@ -236,5 +236,44 @@ class MdmsServiceTest {
         assertEquals(40, result.get().getTotalExpireDays());
         assertFalse(result.get().isRestrictToTodayEnabled());
     }
+
+    @Test
+    void testGetIdPoolConfigParsesData() {
+        when(propertiesManager.getDefaultIdPoolConfig()).thenReturn(org.egov.id.model.IdPoolConfig.builder()
+                .seqCode("id.pool.number")
+                .paddingLength(12)
+                .build());
+
+        Map<String, Object> config = new HashMap<>();
+        config.put("tenantId", "ch");
+        config.put("seqCode", "id.pool.number");
+        config.put("paddingLength", 14);
+
+        JSONArray masterList = new JSONArray();
+        masterList.add(config);
+        Map<String, JSONArray> moduleMap = new HashMap<>();
+        moduleMap.put("IdPoolConfig", masterList);
+        Map<String, Map<String, JSONArray>> mdmsRes = new HashMap<>();
+        mdmsRes.put("beneficiary-idgen", moduleMap);
+
+        when(this.mdmsClientService.getMaster(any(), any(), any()))
+                .thenReturn(new MdmsResponse(new ResponseInfo(), (Map) mdmsRes));
+
+        Optional<org.egov.id.model.IdPoolConfig> result = this.mdmsService.getIdPoolConfig(new RequestInfo(), "ch");
+
+        assertTrue(result.isPresent());
+        assertEquals("id.pool.number", result.get().getSeqCode());
+        assertEquals(14, result.get().getPaddingLength());
+    }
+
+    @Test
+    void testGetIdPoolConfigReturnsEmptyWhenNoData() {
+        when(this.mdmsClientService.getMaster(any(), any(), any()))
+                .thenReturn(new MdmsResponse(new ResponseInfo(), new HashMap<>()));
+
+        Optional<org.egov.id.model.IdPoolConfig> result = this.mdmsService.getIdPoolConfig(new RequestInfo(), "ch");
+
+        assertTrue(result.isEmpty());
+    }
 }
 

--- a/core-services/beneficiary-idgen/src/test/java/org/egov/id/service/MdmsServiceTest.java
+++ b/core-services/beneficiary-idgen/src/test/java/org/egov/id/service/MdmsServiceTest.java
@@ -200,21 +200,18 @@ class MdmsServiceTest {
     void testGetDispatchLimitConfigParsesDataAndAppliesDefaults() {
         when(propertiesManager.getMdmsDispatchLimitModule()).thenReturn("beneficiary-idgen");
         when(propertiesManager.getMdmsDispatchLimitMaster()).thenReturn("IdDispatchConfig");
-        when(propertiesManager.isDispatchLimitUserDevicePerDayEnabled()).thenReturn(true);
+        // Defaults from PropertiesManager for the fields deliberately OMITTED from the MDMS record below.
         when(propertiesManager.getDispatchLimitUserDeviceTotal()).thenReturn(10000);
-        when(propertiesManager.getDispatchLimitUserDevicePerDay()).thenReturn(100);
-        when(propertiesManager.getDispatchUsageUserDevicePerDayExpireDays()).thenReturn(30);
-        when(propertiesManager.getDispatchUsageUserDeviceTotalExpireDays()).thenReturn(30);
+        when(propertiesManager.isDispatchLimitUserDevicePerDayEnabled()).thenReturn(true);
         when(propertiesManager.isIdDispatchRetrievalRestrictToTodayEnabled()).thenReturn(true);
 
+        // MDMS record supplies only a subset of fields; totalLimit, perDayEnabled and restrictToTodayEnabled
+        // are omitted so the parser must fall back to the PropertiesManager defaults for those.
         Map<String, Object> config = new HashMap<>();
         config.put("tenantId", "ch");
-        config.put("totalLimit", 500);
-        config.put("perDayEnabled", false);
         config.put("perDayLimit", 50);
         config.put("perDayExpireDays", 20);
         config.put("totalExpireDays", 40);
-        config.put("restrictToTodayEnabled", false);
 
         JSONArray masterList = new JSONArray();
         masterList.add(config);
@@ -229,12 +226,14 @@ class MdmsServiceTest {
         Optional<org.egov.id.model.DispatchLimitConfig> result = this.mdmsService.getDispatchLimitConfig(new RequestInfo(), "ch");
 
         assertTrue(result.isPresent());
-        assertEquals(500, result.get().getTotalLimit());
-        assertFalse(result.get().isPerDayEnabled());
+        // Explicitly supplied values are parsed as-is.
         assertEquals(50, result.get().getPerDayLimit());
         assertEquals(20, result.get().getPerDayExpireDays());
         assertEquals(40, result.get().getTotalExpireDays());
-        assertFalse(result.get().isRestrictToTodayEnabled());
+        // Omitted fields fall back to the PropertiesManager defaults.
+        assertEquals(10000, result.get().getTotalLimit());
+        assertTrue(result.get().isPerDayEnabled());
+        assertTrue(result.get().isRestrictToTodayEnabled());
     }
 
     @Test


### PR DESCRIPTION
made beneficiary id limits tenant specific

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tenant-specific dispatch limits sourced from MDMS, including per-day/per-total thresholds, expiry windows, and “restrict to today”.
  * Added tenant-aware caching for dispatch-limit configuration with configurable TTL.
  * Added MDMS-driven ID pool configuration (sequence code and padding) used during async ID generation.
* **Configuration**
  * Added MDMS module/master properties for dispatch limits and `dispatch.limit.cache.ttl.minutes`.
  * Updated service configuration to suppress OTEL metrics export.
* **Tests**
  * Added/expanded unit tests for dispatch-limit caching, MDMS parsing/validation, and ID sequence padding behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->