### PR TITLE
Attendance flow fix create resource API

### DIFF
--- a/health-services/project-factory/src/server/__tests__/resourceDetailsService.test.ts
+++ b/health-services/project-factory/src/server/__tests__/resourceDetailsService.test.ts
@@ -82,7 +82,7 @@ jest.mock('uuid', () => ({
 import { createResourceDetail } from '../service/resourceDetailsService';
 import { updateResourceDetail, searchResourceDetails } from '../service/resourceDetailsService';
 import { hasAnyCreatingResource, findActiveResourceByUpsertKey, getResourceDetailById, searchResourceDetailsFromDB, countTotalResourceDetails } from '../utils/resourceDetailsUtils';
-import { isSharedAcrossCampaignFamily } from '../config/resourceTypeRegistry';
+import { isSharedAcrossCampaignFamily, getResourceConfigOrDefault, isRegisteredType } from '../config/resourceTypeRegistry';
 import { produceModifiedMessages } from '../kafka/Producer';
 
 const mockHasAnyCreating = hasAnyCreatingResource as jest.Mock;
@@ -92,6 +92,8 @@ const mockProduce = produceModifiedMessages as jest.Mock;
 const mockSearchFromDB = searchResourceDetailsFromDB as jest.Mock;
 const mockCountTotal = countTotalResourceDetails as jest.Mock;
 const mockIsShared = isSharedAcrossCampaignFamily as jest.Mock;
+const mockGetResourceConfig = getResourceConfigOrDefault as jest.Mock;
+const mockIsRegistered = isRegisteredType as jest.Mock;
 
 // Campaign DB row helpers
 function mockCampaignStatus(status: string) {
@@ -238,6 +240,60 @@ describe('resourceDetailsService — toCreate upsert (no RESOURCE_ALREADY_QUEUED
         );
         expect(createCall).toBeDefined();
         expect(createCall[0].ResourceDetails.status).toBe('toCreate');
+    });
+});
+
+describe('createResourceDetail — registered child type parent handling', () => {
+    const ATTENDEE_INPUT = {
+        tenantId: 'default',
+        campaignId: 'child-campaign-1',
+        type: 'attendanceRegisterAttendee',
+        parentResourceId: 'register-entity-1',
+        fileStoreId: 'fs-new',
+        filename: 'attendee.xlsx',
+        additionalDetails: {}
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockHasAnyCreating.mockResolvedValue(false);
+        mockFindActiveResource.mockResolvedValue(null);
+        mockCampaignStatus('created');
+        mockIsRegistered.mockReturnValue(true);
+        mockGetResourceConfig.mockReturnValue({ parentType: 'attendanceRegister', allowMultiplePerParent: true });
+    });
+
+    it('T13: attendee create succeeds for child campaign with no parent resource under its campaignId', async () => {
+        await createResourceDetail(ATTENDEE_INPUT, 'user-1');
+
+        const validationCall = mockThrowError.mock.calls.find(
+            (args: any[]) => typeof args[3] === 'string' && args[3].includes('No active resource of parent type')
+        );
+        expect(validationCall).toBeUndefined();
+
+        expect(mockProduce).toHaveBeenCalledWith(
+            expect.objectContaining({
+                ResourceDetails: expect.objectContaining({
+                    type: 'attendanceRegisterAttendee',
+                    parentResourceId: 'register-entity-1',
+                    status: 'toCreate'
+                })
+            }),
+            'create-resource-topic',
+            'default'
+        );
+    });
+
+    it('T14: registered child type without parentResourceId still throws VALIDATION_ERROR', async () => {
+        const { parentResourceId, ...noParent } = ATTENDEE_INPUT;
+
+        await expect(createResourceDetail(noParent as any, 'user-1'))
+            .rejects.toThrow('parentResourceId is required');
+
+        expect(mockThrowError).toHaveBeenCalledWith(
+            'COMMON', 400, 'VALIDATION_ERROR', expect.stringContaining('parentResourceId is required')
+        );
+        expect(mockProduce).not.toHaveBeenCalled();
     });
 });
 

--- a/health-services/project-factory/src/server/__tests__/resourceDetailsService.test.ts
+++ b/health-services/project-factory/src/server/__tests__/resourceDetailsService.test.ts
@@ -266,10 +266,10 @@ describe('createResourceDetail — registered child type parent handling', () =>
     it('T13: attendee create succeeds for child campaign with no parent resource under its campaignId', async () => {
         await createResourceDetail(ATTENDEE_INPUT, 'user-1');
 
-        const validationCall = mockThrowError.mock.calls.find(
-            (args: any[]) => typeof args[3] === 'string' && args[3].includes('No active resource of parent type')
+        const parentExistenceLookup = mockFindActiveResource.mock.calls.find(
+            (args: any[]) => args[2] === 'attendanceRegister'
         );
-        expect(validationCall).toBeUndefined();
+        expect(parentExistenceLookup).toBeUndefined();
 
         expect(mockProduce).toHaveBeenCalledWith(
             expect.objectContaining({

--- a/health-services/project-factory/src/server/service/resourceDetailsService.ts
+++ b/health-services/project-factory/src/server/service/resourceDetailsService.ts
@@ -65,13 +65,6 @@ export async function createResourceDetail(
     if (!parentResourceId) {
       throwError("COMMON", 400, "VALIDATION_ERROR", `parentResourceId is required for resource type '${type}'`);
     }
-    // parentResourceId is an external reference (e.g. attendance register ID from the attendance service).
-    // Validate by confirming an active resource of the expected parentType exists for this campaign.
-    const parentResource = await findActiveResourceByUpsertKey(tenantId, campaignId, typeConfig.parentType, null);
-    if (!parentResource) {
-      throwError("COMMON", 400, "VALIDATION_ERROR",
-        `No active resource of parent type '${typeConfig.parentType}' found for campaign '${campaignId}'`);
-    }
     // If not allowMultiplePerParent, check no other active resource of same type+parent
     if (!typeConfig.allowMultiplePerParent) {
       const existingCount = await countResourcesByType(tenantId, campaignId, type, parentResourceId);


### PR DESCRIPTION
fix: allow attendanceRegisterAttendee create for child campaigns by dropping campaignId-scoped parent-existence check

(cherry picked from commit bf6b8e3e5f9e139a8f1a613a632a870fb613af8e)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated child resource creation to require a parent resource ID when needed, preventing invalid submissions.
  * Creation now succeeds when the required parent reference is provided, and fails with a validation error when it is missing.
  * Improved coverage for child resource handling to ensure the expected create behavior is enforced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->