### PR TITLE
Master excel ingestion init pattern

### DIFF
--- a/.github/workflows/buildProjectFactory.yml
+++ b/.github/workflows/buildProjectFactory.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - allValidations
       - master
+      - master-excelIngestionInitPattern
 
 env:
   DOCKER_USERNAME: ${{ vars.DOCKER_USERNAME }}

--- a/.github/workflows/buildProjectFactory.yml
+++ b/.github/workflows/buildProjectFactory.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - allValidations
       - master
-      - nigeria-do-deep-2
-      - master-nigeria-finalpull
-      - master-excelIngestionInitPattern
 
 env:
   DOCKER_USERNAME: ${{ vars.DOCKER_USERNAME }}

--- a/.github/workflows/buildProjectFactory.yml
+++ b/.github/workflows/buildProjectFactory.yml
@@ -7,7 +7,7 @@ on:
       - master
       - nigeria-do-deep-2
       - master-nigeria-finalpull
-      - master-nigeria-finalpull-projectFactory-codeRabbit
+      - master-excelIngestionInitPattern
 
 env:
   DOCKER_USERNAME: ${{ vars.DOCKER_USERNAME }}

--- a/health-services/excel-ingestion/src/main/java/org/egov/excelingestion/consumer/GenerationInitConsumer.java
+++ b/health-services/excel-ingestion/src/main/java/org/egov/excelingestion/consumer/GenerationInitConsumer.java
@@ -71,7 +71,7 @@ public class GenerationInitConsumer {
         this.kafkaTopicConfig = kafkaTopicConfig;
     }
 
-    @KafkaListener(topics = "${excel.ingestion.generation.init.topic}")
+    @KafkaListener(topicPattern = "(${kafka.tenant.id.pattern}){0,1}${excel.ingestion.generation.init.topic}")
     public void consume(GenerateResourceRequest event, Acknowledgment acknowledgment) {
         if (event == null || event.getGenerateResource() == null) {
             log.warn("Received null/invalid generation init event; acking and skipping");

--- a/health-services/excel-ingestion/src/main/java/org/egov/excelingestion/generator/AttendanceRegisterAttendeeSheetGenerator.java
+++ b/health-services/excel-ingestion/src/main/java/org/egov/excelingestion/generator/AttendanceRegisterAttendeeSheetGenerator.java
@@ -16,6 +16,7 @@ import org.egov.excelingestion.util.SchemaColumnDefUtil;
 import org.egov.excelingestion.web.models.mdms.ExcelIngestionGenerateData;
 import org.egov.excelingestion.web.models.*;
 import org.egov.common.contract.request.RequestInfo;
+import org.egov.excelingestion.util.RequestInfoUtil;
 import org.egov.excelingestion.web.models.excel.ColumnDef;
 import org.springframework.stereotype.Component;
 
@@ -104,6 +105,7 @@ public class AttendanceRegisterAttendeeSheetGenerator implements IExcelPopulator
 
         log.info("Generating attendance register attendee sheet: {} for tenant: {}", sheetName, tenantId);
 
+        RequestInfoUtil.ensureUserInfo(requestInfo, tenantId);
         // 1. Fetch schema from MDMS → convert to ColumnDefs
         List<ColumnDef> columnDefs = fetchSchemaColumnDefs(sheetConfig.getSchemaName(), tenantId, requestInfo);
 

--- a/health-services/excel-ingestion/src/main/java/org/egov/excelingestion/generator/AttendanceRegisterAttendeeSheetGenerator.java
+++ b/health-services/excel-ingestion/src/main/java/org/egov/excelingestion/generator/AttendanceRegisterAttendeeSheetGenerator.java
@@ -105,7 +105,7 @@ public class AttendanceRegisterAttendeeSheetGenerator implements IExcelPopulator
 
         log.info("Generating attendance register attendee sheet: {} for tenant: {}", sheetName, tenantId);
 
-        RequestInfoUtil.ensureUserInfo(requestInfo, tenantId);
+        requestInfo = RequestInfoUtil.ensureUserInfo(requestInfo, tenantId);
         // 1. Fetch schema from MDMS → convert to ColumnDefs
         List<ColumnDef> columnDefs = fetchSchemaColumnDefs(sheetConfig.getSchemaName(), tenantId, requestInfo);
 

--- a/health-services/excel-ingestion/src/main/java/org/egov/excelingestion/processor/AttendanceRegisterValidationProcessor.java
+++ b/health-services/excel-ingestion/src/main/java/org/egov/excelingestion/processor/AttendanceRegisterValidationProcessor.java
@@ -14,6 +14,7 @@ import org.egov.excelingestion.exception.CustomExceptionHandler;
 import org.egov.excelingestion.util.BoundaryUtil;
 import org.egov.excelingestion.util.EnrichmentUtil;
 import org.egov.excelingestion.util.ExcelUtil;
+import org.egov.excelingestion.util.RequestInfoUtil;
 import org.egov.excelingestion.web.models.ProcessResource;
 import org.egov.common.contract.request.RequestInfo;
 import org.egov.excelingestion.web.models.ValidationColumnInfo;
@@ -300,6 +301,7 @@ public class AttendanceRegisterValidationProcessor implements IWorkbookProcessor
                .append("&includeAttendee=false")
                .append("&includeStaff=false");
 
+            RequestInfoUtil.ensureUserInfo(requestInfo, tenantId);
             Map<String, Object> payload = new HashMap<>();
             payload.put("RequestInfo", requestInfo);
 

--- a/health-services/excel-ingestion/src/main/java/org/egov/excelingestion/processor/AttendanceRegisterValidationProcessor.java
+++ b/health-services/excel-ingestion/src/main/java/org/egov/excelingestion/processor/AttendanceRegisterValidationProcessor.java
@@ -301,7 +301,7 @@ public class AttendanceRegisterValidationProcessor implements IWorkbookProcessor
                .append("&includeAttendee=false")
                .append("&includeStaff=false");
 
-            RequestInfoUtil.ensureUserInfo(requestInfo, tenantId);
+            requestInfo = RequestInfoUtil.ensureUserInfo(requestInfo, tenantId);
             Map<String, Object> payload = new HashMap<>();
             payload.put("RequestInfo", requestInfo);
 

--- a/health-services/excel-ingestion/src/main/java/org/egov/excelingestion/processor/AttendanceRegisterValidationProcessor.java
+++ b/health-services/excel-ingestion/src/main/java/org/egov/excelingestion/processor/AttendanceRegisterValidationProcessor.java
@@ -252,9 +252,11 @@ public class AttendanceRegisterValidationProcessor implements IWorkbookProcessor
 
         ExecutorService executor = Executors.newFixedThreadPool(Math.min(parallelCalls, batches.size()));
         try {
+            // normalize once before the parallel boundary so tasks don't mutate a shared RequestInfo concurrently
+            RequestInfo resolvedRequestInfo = RequestInfoUtil.ensureUserInfo(requestInfo, tenantId);
             List<Future<?>> futures = new ArrayList<>();
             for (List<String> batch : batches) {
-                futures.add(executor.submit(() -> searchBatch(batch, tenantId, requestInfo, existingServiceCodes)));
+                futures.add(executor.submit(() -> searchBatch(batch, tenantId, resolvedRequestInfo, existingServiceCodes)));
             }
             for (Future<?> future : futures) {
                 try {
@@ -301,7 +303,6 @@ public class AttendanceRegisterValidationProcessor implements IWorkbookProcessor
                .append("&includeAttendee=false")
                .append("&includeStaff=false");
 
-            requestInfo = RequestInfoUtil.ensureUserInfo(requestInfo, tenantId);
             Map<String, Object> payload = new HashMap<>();
             payload.put("RequestInfo", requestInfo);
 

--- a/health-services/excel-ingestion/src/main/java/org/egov/excelingestion/processor/UserValidationProcessor.java
+++ b/health-services/excel-ingestion/src/main/java/org/egov/excelingestion/processor/UserValidationProcessor.java
@@ -14,6 +14,7 @@ import org.egov.excelingestion.util.LocalizationUtil;
 import org.egov.excelingestion.util.BoundaryUtil;
 import org.egov.excelingestion.util.EnrichmentUtil;
 import org.egov.excelingestion.util.ExcelUtil;
+import org.egov.excelingestion.util.RequestInfoUtil;
 import org.egov.excelingestion.service.MDMSService;
 import org.egov.excelingestion.service.CampaignService;
 import org.egov.excelingestion.service.BoundaryService;
@@ -511,6 +512,7 @@ public class UserValidationProcessor implements IWorkbookProcessor {
                                                                      RequestInfo requestInfo) throws Exception {
         String url = config.getHealthIndividualHost() + config.getHealthIndividualSearchPath();
         
+        RequestInfoUtil.ensureUserInfo(requestInfo, tenantId);
         Map<String, Object> searchBody = new HashMap<>();
         searchBody.put("RequestInfo", requestInfo);
         
@@ -553,9 +555,10 @@ public class UserValidationProcessor implements IWorkbookProcessor {
                                                                 RequestInfo requestInfo) throws Exception {
         String url = config.getHealthIndividualHost() + config.getHealthIndividualSearchPath();
         
+        RequestInfoUtil.ensureUserInfo(requestInfo, tenantId);
         Map<String, Object> searchBody = new HashMap<>();
         searchBody.put("RequestInfo", requestInfo);
-        
+
         Map<String, Object> individual = new HashMap<>();
         individual.put("username", usernames);
         searchBody.put("Individual", individual);

--- a/health-services/excel-ingestion/src/main/java/org/egov/excelingestion/processor/UserValidationProcessor.java
+++ b/health-services/excel-ingestion/src/main/java/org/egov/excelingestion/processor/UserValidationProcessor.java
@@ -512,7 +512,7 @@ public class UserValidationProcessor implements IWorkbookProcessor {
                                                                      RequestInfo requestInfo) throws Exception {
         String url = config.getHealthIndividualHost() + config.getHealthIndividualSearchPath();
         
-        RequestInfoUtil.ensureUserInfo(requestInfo, tenantId);
+        requestInfo = RequestInfoUtil.ensureUserInfo(requestInfo, tenantId);
         Map<String, Object> searchBody = new HashMap<>();
         searchBody.put("RequestInfo", requestInfo);
         
@@ -555,7 +555,7 @@ public class UserValidationProcessor implements IWorkbookProcessor {
                                                                 RequestInfo requestInfo) throws Exception {
         String url = config.getHealthIndividualHost() + config.getHealthIndividualSearchPath();
         
-        RequestInfoUtil.ensureUserInfo(requestInfo, tenantId);
+        requestInfo = RequestInfoUtil.ensureUserInfo(requestInfo, tenantId);
         Map<String, Object> searchBody = new HashMap<>();
         searchBody.put("RequestInfo", requestInfo);
 

--- a/health-services/excel-ingestion/src/main/java/org/egov/excelingestion/util/RequestInfoUtil.java
+++ b/health-services/excel-ingestion/src/main/java/org/egov/excelingestion/util/RequestInfoUtil.java
@@ -1,0 +1,45 @@
+package org.egov.excelingestion.util;
+
+import org.egov.common.contract.request.RequestInfo;
+import org.egov.common.contract.request.User;
+
+/**
+ * Shared guard for outbound calls to DIGIT services that reject a request whose
+ * {@code RequestInfo.userInfo} (uuid) is absent - notably the attendance and individual
+ * services, which respond 400 {@code USERINFO "UserInfo is mandatory"}. Async
+ * generation/processing events can arrive without a userInfo (system-triggered or
+ * central-instance flows), so callers must ensure one before invoking those services.
+ */
+public final class RequestInfoUtil {
+
+    private static final String SYSTEM_USER_UUID = "excel-ingestion-system-user";
+    private static final String SYSTEM_USER_TYPE = "SYSTEM";
+
+    private RequestInfoUtil() {
+    }
+
+    /**
+     * Guarantee a non-null userInfo carrying a non-blank uuid and tenantId on the RequestInfo,
+     * mutating it in place. Preserves an existing user's uuid when present.
+     */
+    public static void ensureUserInfo(RequestInfo requestInfo, String tenantId) {
+        if (requestInfo == null) {
+            return;
+        }
+        User user = requestInfo.getUserInfo();
+        if (user == null) {
+            requestInfo.setUserInfo(User.builder()
+                    .uuid(SYSTEM_USER_UUID)
+                    .type(SYSTEM_USER_TYPE)
+                    .tenantId(tenantId)
+                    .build());
+            return;
+        }
+        if (user.getUuid() == null || user.getUuid().isBlank()) {
+            user.setUuid(SYSTEM_USER_UUID);
+        }
+        if (user.getTenantId() == null || user.getTenantId().isBlank()) {
+            user.setTenantId(tenantId);
+        }
+    }
+}

--- a/health-services/excel-ingestion/src/main/java/org/egov/excelingestion/util/RequestInfoUtil.java
+++ b/health-services/excel-ingestion/src/main/java/org/egov/excelingestion/util/RequestInfoUtil.java
@@ -3,13 +3,7 @@ package org.egov.excelingestion.util;
 import org.egov.common.contract.request.RequestInfo;
 import org.egov.common.contract.request.User;
 
-/**
- * Shared guard for outbound calls to DIGIT services that reject a request whose
- * {@code RequestInfo.userInfo} (uuid) is absent - notably the attendance and individual
- * services, which respond 400 {@code USERINFO "UserInfo is mandatory"}. Async
- * generation/processing events can arrive without a userInfo (system-triggered or
- * central-instance flows), so callers must ensure one before invoking those services.
- */
+// Ensures RequestInfo.userInfo is set before calls to services that reject a null userInfo (attendance, individual -> 400 USERINFO).
 public final class RequestInfoUtil {
 
     private static final String SYSTEM_USER_UUID = "excel-ingestion-system-user";
@@ -18,10 +12,6 @@ public final class RequestInfoUtil {
     private RequestInfoUtil() {
     }
 
-    /**
-     * Guarantee a non-null userInfo carrying a non-blank uuid and tenantId on the RequestInfo,
-     * mutating it in place. Preserves an existing user's uuid when present.
-     */
     public static void ensureUserInfo(RequestInfo requestInfo, String tenantId) {
         if (requestInfo == null) {
             return;

--- a/health-services/excel-ingestion/src/main/java/org/egov/excelingestion/util/RequestInfoUtil.java
+++ b/health-services/excel-ingestion/src/main/java/org/egov/excelingestion/util/RequestInfoUtil.java
@@ -3,7 +3,7 @@ package org.egov.excelingestion.util;
 import org.egov.common.contract.request.RequestInfo;
 import org.egov.common.contract.request.User;
 
-// Ensures RequestInfo.userInfo is set before calls to services that reject a null userInfo (attendance, individual -> 400 USERINFO).
+// Guarantees a userInfo.uuid so attendance/individual calls don't fail with 400 USERINFO.
 public final class RequestInfoUtil {
 
     private static final String SYSTEM_USER_UUID = "excel-ingestion-system-user";
@@ -12,24 +12,27 @@ public final class RequestInfoUtil {
     private RequestInfoUtil() {
     }
 
-    public static void ensureUserInfo(RequestInfo requestInfo, String tenantId) {
-        if (requestInfo == null) {
-            return;
-        }
-        User user = requestInfo.getUserInfo();
+    public static RequestInfo ensureUserInfo(RequestInfo requestInfo, String tenantId) {
+        RequestInfo resolved = requestInfo != null ? requestInfo : RequestInfo.builder().build();
+        User user = resolved.getUserInfo();
         if (user == null) {
-            requestInfo.setUserInfo(User.builder()
+            resolved.setUserInfo(User.builder()
                     .uuid(SYSTEM_USER_UUID)
                     .type(SYSTEM_USER_TYPE)
                     .tenantId(tenantId)
                     .build());
-            return;
+            return resolved;
         }
-        if (user.getUuid() == null || user.getUuid().isBlank()) {
+        if (isBlank(user.getUuid())) {
             user.setUuid(SYSTEM_USER_UUID);
         }
-        if (user.getTenantId() == null || user.getTenantId().isBlank()) {
+        if (isBlank(user.getTenantId())) {
             user.setTenantId(tenantId);
         }
+        return resolved;
+    }
+
+    private static boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 }

--- a/health-services/excel-ingestion/src/main/resources/application.properties
+++ b/health-services/excel-ingestion/src/main/resources/application.properties
@@ -98,6 +98,8 @@ egov.worker.registry.search.batch.size=100
 state.level.tenantid.length=1
 is.environment.central.instance=false
 
+kafka.tenant.id.pattern=
+
 # Excel configuration
 excel.row.limit=5000
 excel.max.process.row.limit=100000

--- a/health-services/excel-ingestion/src/test/java/org/egov/excelingestion/util/RequestInfoUtilTest.java
+++ b/health-services/excel-ingestion/src/test/java/org/egov/excelingestion/util/RequestInfoUtilTest.java
@@ -1,0 +1,61 @@
+package org.egov.excelingestion.util;
+
+import org.egov.common.contract.request.RequestInfo;
+import org.egov.common.contract.request.User;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RequestInfoUtilTest {
+
+    private static final String TENANT = "demo";
+    private static final String SYSTEM_UUID = "excel-ingestion-system-user";
+
+    @Test
+    void nullRequestInfo_returnsSystemRequestInfo() {
+        RequestInfo ri = RequestInfoUtil.ensureUserInfo(null, TENANT);
+
+        assertNotNull(ri, "null input must be replaced with a usable RequestInfo, not left null");
+        assertNotNull(ri.getUserInfo());
+        assertEquals(SYSTEM_UUID, ri.getUserInfo().getUuid());
+        assertEquals("SYSTEM", ri.getUserInfo().getType());
+        assertEquals(TENANT, ri.getUserInfo().getTenantId());
+    }
+
+    @Test
+    void nullUserInfo_getsSystemUserWithUuidTypeAndTenant() {
+        RequestInfo ri = RequestInfoUtil.ensureUserInfo(RequestInfo.builder().apiId("pf").build(), TENANT);
+
+        assertNotNull(ri.getUserInfo());
+        assertEquals(SYSTEM_UUID, ri.getUserInfo().getUuid());
+        assertEquals("SYSTEM", ri.getUserInfo().getType());
+        assertEquals(TENANT, ri.getUserInfo().getTenantId());
+        assertEquals("pf", ri.getApiId(), "other RequestInfo fields are preserved");
+    }
+
+    @Test
+    void blankUuid_isBackfilledWithSystemUser() {
+        RequestInfo ri = RequestInfoUtil.ensureUserInfo(
+                RequestInfo.builder().userInfo(User.builder().uuid("   ").tenantId(TENANT).build()).build(), TENANT);
+
+        assertEquals(SYSTEM_UUID, ri.getUserInfo().getUuid());
+        assertEquals(TENANT, ri.getUserInfo().getTenantId());
+    }
+
+    @Test
+    void existingRealUuid_isPreserved() {
+        RequestInfo ri = RequestInfoUtil.ensureUserInfo(
+                RequestInfo.builder().userInfo(User.builder().uuid("real-user-uuid").tenantId(TENANT).build()).build(), TENANT);
+
+        assertEquals("real-user-uuid", ri.getUserInfo().getUuid(), "a real user must never be overwritten");
+    }
+
+    @Test
+    void blankTenant_isBackfilledWhileKeepingRealUuid() {
+        RequestInfo ri = RequestInfoUtil.ensureUserInfo(
+                RequestInfo.builder().userInfo(User.builder().uuid("real-user-uuid").build()).build(), TENANT);
+
+        assertEquals("real-user-uuid", ri.getUserInfo().getUuid());
+        assertEquals(TENANT, ri.getUserInfo().getTenantId());
+    }
+}

--- a/health-services/project-factory/src/server/__tests__/processingResultHandler.requestInfo.test.ts
+++ b/health-services/project-factory/src/server/__tests__/processingResultHandler.requestInfo.test.ts
@@ -1,0 +1,212 @@
+/**
+ * processingResultHandler.requestInfo.test.ts
+ *
+ * Regression tests for the creator-email individual lookup in handleProcessingResult.
+ *
+ * The hcm-processing-result Kafka message only carries `requestInfo` when produced
+ * by excel-ingestion >= PR #2018. Older producers (e.g. the image deployed in the
+ * hcm-demo env) omit it, so `messageObject.requestInfo` is undefined and the
+ * individual/v1/_search body used to be sent WITHOUT RequestInfo — which the
+ * individual service rejects with `NotNull.individualSearchRequest.requestInfo`.
+ *
+ * The fix falls back to a minimal system RequestInfo built from the campaign
+ * creator uuid so the (non-blocking) lookup always passes @NotNull validation,
+ * while still preferring the real requestInfo when the message carries one.
+ */
+
+import { handleProcessingResult } from '../utils/processingResultHandler';
+import { additionalDetailKeys } from '../config/constants';
+
+// ── core service mocks ──────────────────────────────────────────────────────
+jest.mock('../service/campaignManageService', () => ({
+    searchProjectTypeCampaignService: jest.fn(),
+}));
+
+jest.mock('../utils/logger', () => ({
+    logger: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+
+jest.mock('../utils/genericUtils', () => ({
+    getRelatedDataWithCampaign: jest.fn().mockResolvedValue([]),
+    getMappingDataRelatedToCampaign: jest.fn().mockResolvedValue([]),
+    prepareProcessesInDb: jest.fn().mockResolvedValue(undefined),
+    getRelatedDataWithUniqueIdentifiers: jest.fn().mockResolvedValue([]),
+    checkCampaignDataCompletionStatus: jest.fn().mockResolvedValue({ allCompleted: true, anyFailed: false }),
+    checkCampaignMappingCompletionStatus: jest.fn().mockResolvedValue({ allCompleted: true }),
+    throwError: jest.fn().mockImplementation((_module: any, status: any, code: any, description: any) => {
+        throw Object.assign(new Error(description || code), { status, code });
+    }),
+    getCurrentProcesses: jest.fn().mockResolvedValue([]),
+    pollUntilCount: jest.fn().mockResolvedValue(undefined),
+    pollUntilCountFn: jest.fn().mockResolvedValue(undefined),
+    deleteCampaignDataFailedAndInvalid: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../utils/campaignFailureHandler', () => ({
+    sendCampaignFailureMessage: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../utils/request', () => ({
+    httpRequest: jest.fn().mockResolvedValue({ Individual: [] }),
+}));
+
+jest.mock('../utils/redisUtils', () => ({
+    getCache: jest.fn(),
+    setCache: jest.fn(),
+    deleteCache: jest.fn(),
+}));
+
+jest.mock('../kafka/Producer', () => ({
+    produceModifiedMessages: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../api/coreApis', () => ({
+    searchMDMSDataViaV2Api: jest.fn().mockResolvedValue({}),
+    searchBoundaryRelationshipData: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('../api/campaignApis', () => ({
+    confirmProjectParentCreation: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('../utils/campaignUtils', () => ({
+    populateBoundariesRecursively: jest.fn().mockResolvedValue(undefined),
+    getLocalizedName: jest.fn((k: string) => k),
+    enrichAndPersistCampaignWithError: jest.fn().mockResolvedValue(undefined),
+    enrichAndPersistCampaignForCreateViaFlow2: jest.fn().mockResolvedValue(undefined),
+    userCredGeneration: jest.fn().mockResolvedValue(undefined),
+    markAllToCreateResourcesAsCompleted: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../utils/localisationUtils', () => ({
+    getLocalisationModuleName: jest.fn().mockReturnValue('hcm-admin-console'),
+}));
+
+jest.mock('../controllers/localisationController/localisation.controller', () => ({
+    __esModule: true,
+    default: {
+        getInstance: jest.fn().mockReturnValue({
+            getLocalisationData: jest.fn().mockResolvedValue([]),
+        }),
+    },
+}));
+
+jest.mock('../utils/excelIngestionUtils', () => ({
+    searchSheetData: jest.fn().mockResolvedValue([]),
+    getSheetDataCount: jest.fn().mockResolvedValue(0),
+    forEachSheetDataPage: jest.fn().mockResolvedValue(0),
+    getSheetFetchPageSize: jest.fn().mockReturnValue(2000),
+}));
+
+jest.mock('../utils/onGoingCampaignUpdateUtils', () => ({
+    fetchProjectsWithBoundaryCodeAndReferenceId: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('../utils/mailUtils', () => ({
+    triggerUserCredentialEmailFlow: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../utils/transforms/projectTypeUtils', () => ({
+    enrichProjectDetailsFromCampaignDetails: jest.fn().mockResolvedValue(undefined),
+}));
+
+// ── imports that must come after all mocks ───────────────────────────────────
+import { searchProjectTypeCampaignService } from '../service/campaignManageService';
+import { httpRequest } from '../utils/request';
+import config from '../config';
+
+const searchCampaignMock = searchProjectTypeCampaignService as jest.MockedFunction<typeof searchProjectTypeCampaignService>;
+const httpRequestMock = httpRequest as jest.MockedFunction<typeof httpRequest>;
+
+const CREATOR_UUID = 'creator-uuid-123';
+
+// Campaign whose creator uuid drives the individual lookup + the RequestInfo fallback.
+const CAMPAIGN_WITH_CREATOR = {
+    id: 'campaign-x',
+    tenantId: 'demo',
+    parentId: null,
+    status: 'active',
+    campaignNumber: 'CMP-TEST',
+    campaignName: 'Test Campaign',
+    auditDetails: { createdBy: CREATOR_UUID },
+};
+
+// A message that hard-blocks right after the creator lookup (boundary invalid),
+// so the handler exits fast — the individual search has already been dispatched.
+function buildMessage(requestInfo?: any): any {
+    return {
+        tenantId: 'demo',
+        referenceId: 'campaign-x',
+        fileStoreId: 'file-1',
+        status: 'completed',
+        ...(requestInfo ? { requestInfo } : {}),
+        additionalDetails: {
+            [additionalDetailKeys.boundarySheetStatus]: 'invalid',
+            [additionalDetailKeys.userSheetStatus]: 'valid',
+            [additionalDetailKeys.facilitySheetStatus]: 'valid',
+            [additionalDetailKeys.validationStatus]: 'invalid',
+        },
+    };
+}
+
+// Extract the body passed to the individual/v1/_search lookup (type=EMPLOYEE).
+function getIndividualSearchBody(): any {
+    const searchUrl = config.host.healthIndividualHost + config.paths.healthIndividualSearch;
+    const call = httpRequestMock.mock.calls.find(
+        (c) => c[0] === searchUrl && (c[1] as any)?.Individual?.type === 'EMPLOYEE'
+    );
+    return call ? (call[1] as any) : undefined;
+}
+
+describe('handleProcessingResult: creator-email individual lookup RequestInfo', () => {
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        searchCampaignMock.mockResolvedValue({ CampaignDetails: [CAMPAIGN_WITH_CREATOR] } as any);
+        httpRequestMock.mockResolvedValue({ Individual: [] } as any);
+    });
+
+    it('falls back to a system RequestInfo built from the campaign creator when the message has no requestInfo', async () => {
+        await handleProcessingResult(buildMessage());
+
+        const body = getIndividualSearchBody();
+        expect(body).toBeDefined();
+        expect(body.RequestInfo).toEqual({ userInfo: { uuid: CREATOR_UUID } });
+        expect(body.Individual.userUuid).toEqual([CREATOR_UUID]);
+    });
+
+    it('prefers the real requestInfo from the message when present (excel-ingestion >= PR #2018)', async () => {
+        const realRequestInfo = {
+            apiId: 'pf',
+            authToken: 'tok-abc',
+            userInfo: { uuid: 'real-user', tenantId: 'demo' },
+        };
+
+        await handleProcessingResult(buildMessage(realRequestInfo));
+
+        const body = getIndividualSearchBody();
+        expect(body).toBeDefined();
+        expect(body.RequestInfo).toEqual(realRequestInfo);
+    });
+
+    it('never sends the individual lookup with a null/undefined RequestInfo', async () => {
+        await handleProcessingResult(buildMessage());
+
+        const body = getIndividualSearchBody();
+        expect(body).toBeDefined();
+        expect(body.RequestInfo).not.toBeNull();
+        expect(body.RequestInfo).not.toBeUndefined();
+    });
+
+    it('injects a creator userInfo when the message requestInfo is present but its userInfo is missing', async () => {
+        const requestInfoWithoutUser = { apiId: 'pf', authToken: 'tok-abc' };
+
+        await handleProcessingResult(buildMessage(requestInfoWithoutUser));
+
+        const body = getIndividualSearchBody();
+        expect(body).toBeDefined();
+        // preserves the incoming fields, but guarantees a userInfo the individual service accepts
+        expect(body.RequestInfo).toEqual({ apiId: 'pf', authToken: 'tok-abc', userInfo: { uuid: CREATOR_UUID } });
+        expect(body.RequestInfo.userInfo).toEqual({ uuid: CREATOR_UUID });
+    });
+});

--- a/health-services/project-factory/src/server/__tests__/processingResultHandler.requestInfo.test.ts
+++ b/health-services/project-factory/src/server/__tests__/processingResultHandler.requestInfo.test.ts
@@ -14,7 +14,7 @@
  * while still preferring the real requestInfo when the message carries one.
  */
 
-import { handleProcessingResult } from '../utils/processingResultHandler';
+import { handleProcessingResult, resolveCreationRequestInfo } from '../utils/processingResultHandler';
 import { additionalDetailKeys } from '../config/constants';
 
 // ── core service mocks ──────────────────────────────────────────────────────
@@ -208,5 +208,46 @@ describe('handleProcessingResult: creator-email individual lookup RequestInfo', 
         // preserves the incoming fields, but guarantees a userInfo the individual service accepts
         expect(body.RequestInfo).toEqual({ apiId: 'pf', authToken: 'tok-abc', userInfo: { uuid: CREATOR_UUID } });
         expect(body.RequestInfo.userInfo).toEqual({ uuid: CREATOR_UUID });
+    });
+});
+
+// Covers the background-flow RequestInfo construction (handler line ~356) that drives user/project/facility creation.
+describe('resolveCreationRequestInfo (background resource-creation fallback)', () => {
+    const TENANT = 'demo';
+
+    it('preserves the real requestInfo when it already carries a userInfo.uuid', () => {
+        const real = { apiId: 'pf', authToken: 'tok', userInfo: { uuid: 'real-user', tenantId: TENANT } } as any;
+
+        const out = resolveCreationRequestInfo(real, CREATOR_UUID, TENANT);
+
+        expect(out).toBe(real); // same reference, untouched
+        expect(out.userInfo?.uuid).toBe('real-user');
+    });
+
+    it('injects the campaign creator uuid when userInfo.uuid is missing', () => {
+        const out = resolveCreationRequestInfo({ apiId: 'pf' } as any, CREATOR_UUID, TENANT);
+
+        expect(out.userInfo).toEqual({ uuid: CREATOR_UUID, tenantId: TENANT });
+        expect(out.apiId).toBe('pf'); // existing fields preserved
+    });
+
+    it('builds a creator RequestInfo when the incoming requestInfo is undefined', () => {
+        const out = resolveCreationRequestInfo(undefined, CREATOR_UUID, TENANT);
+
+        expect(out.userInfo).toEqual({ uuid: CREATOR_UUID, tenantId: TENANT });
+    });
+
+    it('does NOT fabricate a userInfo when there is no creator uuid (avoids uuid:undefined)', () => {
+        const out = resolveCreationRequestInfo({ apiId: 'pf' } as any, undefined, TENANT);
+
+        // returns the raw requestInfo so the downstream guard fails clearly, instead of a userInfo with a dropped uuid
+        expect(out.userInfo).toBeUndefined();
+        expect(out.apiId).toBe('pf');
+    });
+
+    it('returns an empty object (no crash) when both requestInfo and creator are absent', () => {
+        const out = resolveCreationRequestInfo(undefined, undefined, TENANT);
+
+        expect(out).toEqual({});
     });
 });

--- a/health-services/project-factory/src/server/utils/processingResultHandler.ts
+++ b/health-services/project-factory/src/server/utils/processingResultHandler.ts
@@ -83,6 +83,17 @@ async function fetchLocalizationData(tenantId: string, campaignId: string, local
     }
 }
 
+// Resolve the RequestInfo for background resource creation: keep a real userInfo, else stamp the campaign creator, else leave it for the downstream userInfo guard.
+export function resolveCreationRequestInfo(requestInfo: RequestInfo | undefined, campaignCreatedBy: string | undefined, tenantId: string): RequestInfo {
+    if (requestInfo?.userInfo?.uuid) {
+        return requestInfo;
+    }
+    if (campaignCreatedBy) {
+        return withUserInfo(requestInfo ?? ({} as RequestInfo), { uuid: campaignCreatedBy, tenantId });
+    }
+    return requestInfo ?? ({} as RequestInfo);
+}
+
 /**
  * Handler for HCM processing result messages from excel-ingestion service
  * This handler receives the ProcessResource object after Excel processing is complete
@@ -352,12 +363,8 @@ export async function handleProcessingResult(messageObject: any) {
 
                 // Trigger background resource creation and mapping flow
                 logger.info('=== TRIGGERING BACKGROUND RESOURCE CREATION FLOW ===');
-                // ensure a userInfo (creator uuid) — user-creation batches require it; skip when no creator uuid to avoid a userInfo with an undefined uuid
-                const creationRequestInfo = messageObject?.requestInfo?.userInfo?.uuid
-                    ? messageObject.requestInfo
-                    : campaignCreatedBy
-                        ? withUserInfo(messageObject?.requestInfo ?? {}, { uuid: campaignCreatedBy, tenantId: messageObject.tenantId })
-                        : messageObject?.requestInfo ?? {};
+                // ensure userInfo (creator uuid) for user-creation batches; skip when no creator uuid
+                const creationRequestInfo = resolveCreationRequestInfo(messageObject?.requestInfo, campaignCreatedBy, messageObject.tenantId);
                 await triggerBackgroundResourceCreationFlow(messageObject.tenantId, campaignDetails, parentCampaign, locale, createdByEmail, creationRequestInfo, expectedUserCount, expectedBoundaryCount);
             } else {
                 throw new Error('No temp data found to process for campaign');

--- a/health-services/project-factory/src/server/utils/processingResultHandler.ts
+++ b/health-services/project-factory/src/server/utils/processingResultHandler.ts
@@ -160,8 +160,8 @@ export async function handleProcessingResult(messageObject: any) {
                         offset: 0,
                         tenantId: messageObject.tenantId,
                     };
-                    // RequestInfo is now expected to be available in the processing message.
-                    // Use it directly for Individual Search instead of reconstructing user context.
+                    // The processing message carries the RequestInfo; use it when it has a userInfo,
+                    // otherwise fall back to one built from the campaign creator uuid.
                     const searchBody = {
                         RequestInfo: messageObject?.requestInfo?.userInfo
                             ? messageObject.requestInfo
@@ -364,8 +364,8 @@ export async function handleProcessingResult(messageObject: any) {
 
                 // Trigger background resource creation and mapping flow
                 logger.info('=== TRIGGERING BACKGROUND RESOURCE CREATION FLOW ===');
-                // Pass the original RequestInfo to the background resource creation flow.
-                // Downstream services use this request context directly.
+                // Resolve the RequestInfo for the background creation flow: keep the message's userInfo
+                // when present, else stamp the campaign creator so user-creation batches have a valid user.
                 const creationRequestInfo = resolveCreationRequestInfo(messageObject?.requestInfo, campaignCreatedBy, messageObject.tenantId);
                 await triggerBackgroundResourceCreationFlow(messageObject.tenantId, campaignDetails, parentCampaign, locale, createdByEmail, creationRequestInfo, expectedUserCount, expectedBoundaryCount);
             } else {

--- a/health-services/project-factory/src/server/utils/processingResultHandler.ts
+++ b/health-services/project-factory/src/server/utils/processingResultHandler.ts
@@ -352,10 +352,12 @@ export async function handleProcessingResult(messageObject: any) {
 
                 // Trigger background resource creation and mapping flow
                 logger.info('=== TRIGGERING BACKGROUND RESOURCE CREATION FLOW ===');
-                // ensure a userInfo (creator uuid) — user-creation batches require it
+                // ensure a userInfo (creator uuid) — user-creation batches require it; skip when no creator uuid to avoid a userInfo with an undefined uuid
                 const creationRequestInfo = messageObject?.requestInfo?.userInfo?.uuid
                     ? messageObject.requestInfo
-                    : withUserInfo(messageObject?.requestInfo ?? {}, { uuid: campaignCreatedBy, tenantId: messageObject.tenantId });
+                    : campaignCreatedBy
+                        ? withUserInfo(messageObject?.requestInfo ?? {}, { uuid: campaignCreatedBy, tenantId: messageObject.tenantId })
+                        : messageObject?.requestInfo ?? {};
                 await triggerBackgroundResourceCreationFlow(messageObject.tenantId, campaignDetails, parentCampaign, locale, createdByEmail, creationRequestInfo, expectedUserCount, expectedBoundaryCount);
             } else {
                 throw new Error('No temp data found to process for campaign');

--- a/health-services/project-factory/src/server/utils/processingResultHandler.ts
+++ b/health-services/project-factory/src/server/utils/processingResultHandler.ts
@@ -160,7 +160,8 @@ export async function handleProcessingResult(messageObject: any) {
                         offset: 0,
                         tenantId: messageObject.tenantId,
                     };
-                    // ensure a userInfo (creator uuid) — individual search rejects a null userInfo
+                    // RequestInfo is now expected to be available in the processing message.
+                    // Use it directly for Individual Search instead of reconstructing user context.
                     const searchBody = {
                         RequestInfo: messageObject?.requestInfo?.userInfo
                             ? messageObject.requestInfo
@@ -363,7 +364,8 @@ export async function handleProcessingResult(messageObject: any) {
 
                 // Trigger background resource creation and mapping flow
                 logger.info('=== TRIGGERING BACKGROUND RESOURCE CREATION FLOW ===');
-                // ensure userInfo (creator uuid) for user-creation batches; skip when no creator uuid
+                // Pass the original RequestInfo to the background resource creation flow.
+                // Downstream services use this request context directly.
                 const creationRequestInfo = resolveCreationRequestInfo(messageObject?.requestInfo, campaignCreatedBy, messageObject.tenantId);
                 await triggerBackgroundResourceCreationFlow(messageObject.tenantId, campaignDetails, parentCampaign, locale, createdByEmail, creationRequestInfo, expectedUserCount, expectedBoundaryCount);
             } else {

--- a/health-services/project-factory/src/server/utils/processingResultHandler.ts
+++ b/health-services/project-factory/src/server/utils/processingResultHandler.ts
@@ -149,7 +149,7 @@ export async function handleProcessingResult(messageObject: any) {
                         offset: 0,
                         tenantId: messageObject.tenantId,
                     };
-                    // hcm-processing-result may carry no requestInfo (excel-ingestion < PR #2018) OR a requestInfo whose userInfo is null (system-triggered flows). Both fail the individual service's @NotNull(userInfo). Ensure a userInfo (campaign creator uuid) is always present for this non-blocking lookup, while preserving a real requestInfo when it already has one.
+                    // ensure a userInfo (creator uuid) — individual search rejects a null userInfo
                     const searchBody = {
                         RequestInfo: messageObject?.requestInfo?.userInfo
                             ? messageObject.requestInfo
@@ -352,7 +352,7 @@ export async function handleProcessingResult(messageObject: any) {
 
                 // Trigger background resource creation and mapping flow
                 logger.info('=== TRIGGERING BACKGROUND RESOURCE CREATION FLOW ===');
-                // hcm-processing-result may omit requestInfo, or carry one whose userInfo is null (central-instance / system-triggered flows). The background user-creation batches hard-require userInfo.uuid (IDGen username generation), so fall back to the campaign creator while preserving a real userInfo when present.
+                // ensure a userInfo (creator uuid) — user-creation batches require it
                 const creationRequestInfo = messageObject?.requestInfo?.userInfo?.uuid
                     ? messageObject.requestInfo
                     : withUserInfo(messageObject?.requestInfo ?? {}, { uuid: campaignCreatedBy, tenantId: messageObject.tenantId });

--- a/health-services/project-factory/src/server/utils/processingResultHandler.ts
+++ b/health-services/project-factory/src/server/utils/processingResultHandler.ts
@@ -1,4 +1,4 @@
-import { RequestInfo } from "../config/models/requestInfoSchema";
+import { RequestInfo, withUserInfo } from "../config/models/requestInfoSchema";
 import { logger } from './logger';
 import { getSheetDataCount, forEachSheetDataPage, getSheetFetchPageSize } from './excelIngestionUtils';
 import { searchProjectTypeCampaignService } from '../service/campaignManageService';
@@ -149,8 +149,11 @@ export async function handleProcessingResult(messageObject: any) {
                         offset: 0,
                         tenantId: messageObject.tenantId,
                     };
+                    // hcm-processing-result may carry no requestInfo (excel-ingestion < PR #2018) OR a requestInfo whose userInfo is null (system-triggered flows). Both fail the individual service's @NotNull(userInfo). Ensure a userInfo (campaign creator uuid) is always present for this non-blocking lookup, while preserving a real requestInfo when it already has one.
                     const searchBody = {
-                        RequestInfo: messageObject?.requestInfo,
+                        RequestInfo: messageObject?.requestInfo?.userInfo
+                            ? messageObject.requestInfo
+                            : { ...(messageObject?.requestInfo ?? {}), userInfo: { uuid: campaignCreatedBy } },
                         Individual: {
                             type: "EMPLOYEE",
                             userUuid: [campaignCreatedBy],
@@ -349,7 +352,11 @@ export async function handleProcessingResult(messageObject: any) {
 
                 // Trigger background resource creation and mapping flow
                 logger.info('=== TRIGGERING BACKGROUND RESOURCE CREATION FLOW ===');
-                await triggerBackgroundResourceCreationFlow(messageObject.tenantId, campaignDetails, parentCampaign, locale, createdByEmail, messageObject?.requestInfo, expectedUserCount, expectedBoundaryCount);
+                // hcm-processing-result may omit requestInfo, or carry one whose userInfo is null (central-instance / system-triggered flows). The background user-creation batches hard-require userInfo.uuid (IDGen username generation), so fall back to the campaign creator while preserving a real userInfo when present.
+                const creationRequestInfo = messageObject?.requestInfo?.userInfo?.uuid
+                    ? messageObject.requestInfo
+                    : withUserInfo(messageObject?.requestInfo ?? {}, { uuid: campaignCreatedBy, tenantId: messageObject.tenantId });
+                await triggerBackgroundResourceCreationFlow(messageObject.tenantId, campaignDetails, parentCampaign, locale, createdByEmail, creationRequestInfo, expectedUserCount, expectedBoundaryCount);
             } else {
                 throw new Error('No temp data found to process for campaign');
             }


### PR DESCRIPTION
 Issue: Campaign creation and Excel template generation/download were failing on the central-instance (hcm-demo/nigeria) cluster while working on unified-uat. Two distinct root causes were
  involved. (1) Kafka topic mismatch under central instance: the excel-ingestion GenerationInitConsumer (added in PR #2018) subscribed to a fixed, un-prefixed topic
  (excel-ingestion-generation-init), but under central instance the producer tenant-prefixes topics (e.g. demo-excel-ingestion-generation-init). The consumer therefore never received the
  generation-init events, so template generation silently hung and downloads never completed. (2) Missing userInfo on inter-service calls: PR #2018 also added strict guards requiring
  RequestInfo.userInfo, but the async campaign-processing/generation flows pass a RequestInfo whose userInfo is null, so downstream calls to the attendance and health-individual services
  (which mandate userInfo) were rejected with 400 USERINFO "UserInfo is mandatory", and project-factory's background user-creation flow threw RequestInfo with userInfo is required for user 
  creation batches.

  Fix: For the topic mismatch, the consumer now subscribes by pattern — @KafkaListener(topicPattern = "(${kafka.tenant.id.pattern}){0,1}${excel.ingestion.generation.init.topic}") — matching
  both the state-prefixed topic (central instance) and the plain topic (non-central), with kafka.tenant.id.pattern sourced from egov-config. For the userInfo problem, a shared
  RequestInfoUtil.ensureUserInfo(...) guard was added in excel-ingestion and applied before every outbound call to the attendance/individual services (attendee generator + validation
  processors); it injects a system/creator userInfo when one is absent and preserves a real user when present. In project-factory, the hcm-processing-result individual lookup was made
  userInfo-aware and the background resource-creation flow now enriches the RequestInfo with the campaign-creator uuid before triggering user/project/facility creation. Verified with 375
  excel-ingestion tests green, project-factory typecheck + targeted tests passing, and a live local run confirming correct topic subscription in both central-instance-on and -off modes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tenant-aware Kafka topic-pattern subscription for Excel ingestion, along with a new `kafka.tenant.id.pattern` configuration.
* **Bug Fixes**
  * Improved `RequestInfo`/`userInfo` normalization across Excel ingestion (attendance register generation/validation and user validation) and campaign result handling so downstream requests always get a valid `userInfo.uuid`, with safe fallbacks when missing or incomplete.
* **Tests**
  * Expanded Jest tests for creator-email individual lookup/requestInfo behavior and added JUnit tests for `RequestInfoUtil.ensureUserInfo`.
* **Chores**
  * Updated CI branch triggers to include `master-excelIngestionInitPattern`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->