### PR TITLE
feat(custom-reports): status lifecycle tracking custom-range date fix and localizable column headers

### DIFF
--- a/utilities/airflow-dags/dags/common/kafka_status.py
+++ b/utilities/airflow-dags/dags/common/kafka_status.py
@@ -1,0 +1,163 @@
+"""
+common/kafka_status.py
+
+Shared helper for pushing report-generation lifecycle/status events to Kafka
+from the Airflow DAGs (hcm_campaign_scheduler, hcm_dynamic_campaigns).
+
+Uses the same event schema and tenant-topic-prefixing convention as
+hcm-custom-reports/main.py's push_report_status, so all lifecycle events for
+a given campaign/report/frequency land on one topic (CUSTOM_REPORTS_AUTOMATION_TOPIC,
+i.e. save-hcm-report-metadata -> REPORTS_METADATA) regardless of which component
+(scheduler DAG, processor DAG, or the report pod) produced them.
+
+Required env vars:
+    KAFKA_BROKER          - Kafka bootstrap servers
+Optional:
+    CUSTOM_REPORTS_AUTOMATION_TOPIC (default: "save-hcm-report-metadata")
+    TENANT_ID                       (default: "dev")
+    IS_CENTRAL_INSTANCE_ENABLED     (default: "false")
+"""
+from __future__ import annotations
+
+import datetime
+import json
+import logging
+import os
+import uuid
+
+logger = logging.getLogger("airflow.task")
+
+CUSTOM_REPORTS_AUTOMATION_TOPIC = os.getenv("CUSTOM_REPORTS_AUTOMATION_TOPIC", "save-hcm-report-metadata")
+KAFKA_BROKER = os.getenv("KAFKA_BROKER")
+TENANT_ID_DEFAULT = os.getenv("TENANT_ID", "dev")
+IS_CENTRAL_INSTANCE_ENABLED = os.getenv("IS_CENTRAL_INSTANCE_ENABLED", "false").lower() == "true"
+
+# Mirrors STATUS_ORDER in hcm-custom-reports/main.py - keep the two in sync.
+STATUS_ORDER = {
+    "SCHEDULED": 10,
+    "TRIGGERED": 20,
+    "SKIPPED": 20,
+    "POD_STARTED": 30,
+    "REPORT_GENERATION_STARTED": 31,
+    "ZIP_STARTED": 32,
+    "FILESTORE_UPLOAD_STARTED": 33,
+    "POD_INFRA_FAILED": 40,
+    "ENV_VALIDATION_FAILED": 40,
+    "REPORT_GENERATION_FAILED": 40,
+    "OUTPUT_NOT_FOUND_FAILED": 40,
+    "ZIP_FAILED": 40,
+    "FILESTORE_UPLOAD_FAILED": 40,
+    "REPORT_COMPLETED": 40,
+}
+
+_producer = None
+_producer_init_failed = False
+
+
+def _get_producer():
+    """Lazily construct a module-level KafkaProducer. Returns None if unavailable."""
+    global _producer, _producer_init_failed
+    if _producer is not None or _producer_init_failed:
+        return _producer
+    try:
+        from kafka import KafkaProducer
+
+        _producer = KafkaProducer(
+            bootstrap_servers=KAFKA_BROKER,
+            value_serializer=lambda v: json.dumps(v).encode("utf-8"),
+        )
+    except Exception:
+        logger.exception("[KAFKA] Failed to initialize KafkaProducer for status events")
+        _producer_init_failed = True
+        _producer = None
+    return _producer
+
+
+def _topic_for(base_topic, tenant_id):
+    return f"{tenant_id}-{base_topic}" if IS_CENTRAL_INSTANCE_ENABLED and tenant_id else base_topic
+
+
+def push_status_event(status, campaign, dag_id, dag_run_id, error_message=None,
+                       report_triggered_time_ms=None, report_triggered_time=None,
+                       expected_rows=None, expected_generation_time_seconds=None,
+                       report_dates=None):
+    """
+    Push one lifecycle status event for a campaign+report+frequency combination.
+
+    Args:
+        status (str): one of the keys in STATUS_ORDER.
+        campaign (dict): matched-campaign dict as produced by hcm_campaign_scheduler
+            (must have campaignIdentifier, identifierType, reportName, triggerFrequency,
+            triggerTime, tenantId; may have startDate/endDate/reportStartTime/reportEndTime).
+        dag_id (str): DAG producing this event (e.g. "hcm_campaign_scheduler").
+        dag_run_id (str): the DAG run id this event belongs to.
+        error_message (str, optional): human-readable reason, used for SKIPPED/FAILED statuses.
+        report_triggered_time_ms / report_triggered_time (optional): the actual wall-clock
+            moment this specific run was triggered (distinct from campaign["triggerTime"],
+            which is just the MDMS-configured time-of-day, or whatever the requester sent
+            for a CUSTOM report). Callers should pass the same value for every event
+            belonging to one run so it reads consistently across all its status rows.
+        expected_rows / expected_generation_time_seconds (optional): estimates computed
+            once at trigger time (airflow-trigger-service's trigger_dag) and threaded
+            through conf/env vars unchanged, same "stamp once, carry through" pattern as
+            report_triggered_time_ms - lets the UI show an estimate for the whole lifecycle
+            of a run, not just its first event.
+        report_dates (optional): "<start> to <end>" range string, same format main.py uses
+            (f"{START_DATE}_{END_DATE}"). Only known once compute_range() has run - build_payload
+            has it by the time it pushes TRIGGERED; earlier statuses (SCHEDULED, SKIPPED) don't
+            and should leave this as None.
+
+    Never raises - a Kafka hiccup must not fail a DAG task.
+    """
+    producer = _get_producer()
+    if producer is None:
+        logger.warning("[KAFKA] Skipping status event %s (producer unavailable)", status)
+        return
+
+    tenant_id = campaign.get("tenantId", TENANT_ID_DEFAULT)
+    now_dt = datetime.datetime.now(datetime.timezone.utc)
+    timestamp_ms = int(now_dt.timestamp() * 1000)
+    # How long after trigger this specific event happened - gives a per-stage timeline
+    # (e.g. TRIGGERED at +5s, POD_STARTED at +52s) for every row, not just completed runs.
+    seconds_since_triggered = (
+        round((timestamp_ms - report_triggered_time_ms) / 1000, 2)
+        if report_triggered_time_ms is not None else None
+    )
+    event = {
+        "event_id": str(uuid.uuid4()),
+        "tenant_id": tenant_id,
+        "campaign_identifier": campaign.get("campaignIdentifier"),
+        "identifier_type": campaign.get("identifierType"),
+        "report_name": campaign.get("reportName"),
+        "trigger_frequency": campaign.get("triggerFrequency"),
+        "trigger_time": campaign.get("triggerTime"),
+        "report_triggered_time_ms": report_triggered_time_ms,
+        "report_triggered_time": report_triggered_time,
+        "expected_rows": expected_rows,
+        "expected_generation_time_seconds": expected_generation_time_seconds,
+        "seconds_since_triggered": seconds_since_triggered,
+        "dag_run_id": dag_run_id,
+        "dag_name": dag_id,
+        "status": status,
+        "status_order": STATUS_ORDER.get(status, 0),
+        "error_message": error_message,
+        "error_type": None,
+        "file_store_id": None,
+        "file_size_bytes": None,
+        "row_count": None,
+        "report_dates": report_dates,
+        "report_generation_time_seconds": None,
+        # Epoch millis is what's actually bound into the DB (plain number -> BIGINT,
+        # no JDBC string-to-timestamp cast risk); ISO string kept for readability only.
+        "timestamp_ms": timestamp_ms,
+        "timestamp": now_dt.isoformat(),
+    }
+
+    topic = _topic_for(CUSTOM_REPORTS_AUTOMATION_TOPIC, tenant_id)
+    try:
+        producer.send(topic, value=event)
+        producer.flush(timeout=10)
+        logger.info("[KAFKA] Pushed status=%s for %s/%s to topic %s",
+                    status, event["campaign_identifier"], event["report_name"], topic)
+    except Exception:
+        logger.exception("[KAFKA] Failed to push status event %s to topic %s", status, topic)

--- a/utilities/airflow-dags/dags/hcm_campaign_scheduler.py
+++ b/utilities/airflow-dags/dags/hcm_campaign_scheduler.py
@@ -33,6 +33,8 @@ from airflow.utils.types import DagRunType
 from airflow.operators.trigger_dagrun import TriggerDagRunOperator
 from airflow.models import Variable
 
+from common.kafka_status import push_status_event
+
 logger = logging.getLogger("airflow.task")
 logger.setLevel(logging.INFO)
 
@@ -43,7 +45,7 @@ MDMS_URL = os.getenv("MDMS_URL")
 MDMS_SEARCH_ENDPOINT = os.getenv("MDMS_SEARCH_ENDPOINT", "/mdms-v2/v2/_search")
 MDMS_MODULE_NAME = os.getenv("MDMS_MODULE_NAME", "airflow-configs")
 MDMS_MASTER_NAME = os.getenv("MDMS_MASTER_NAME", "campaign-report-config")
-TENANT_ID = os.getenv("TENANT_ID", "dev")
+TENANT_ID = os.getenv("TENANT_ID", "ba")
 MDMS_LIMIT = int(os.getenv("MDMS_LIMIT", "500"))
 PROCESSOR_DAG_ID = os.getenv("PROCESSOR_DAG_ID", "hcm_dynamic_campaigns")
 IS_CENTRAL_INSTANCE_ENABLED = os.getenv("IS_CENTRAL_INSTANCE_ENABLED", "false").lower() == "true"
@@ -511,7 +513,19 @@ with DAG(
             return "no_triggers"
 
 
-        run_id = f"auto_trigger__{datetime.now(UTC).strftime('%Y%m%d_%H%M%S')}"
+        now = datetime.now(UTC)
+        run_id = f"auto_trigger__{now.strftime('%Y%m%d_%H%M%S')}"
+
+        # The actual moment this batch got triggered - distinct from each campaign's
+        # configured triggerTime (MDMS time-of-day). Stamped once here and carried through
+        # conf so every later status event for these runs (TRIGGERED, POD_STARTED, ...,
+        # terminal) reports the identical value instead of each DAG/pod computing its own.
+        report_triggered_time_ms = int(now.timestamp() * 1000)
+        report_triggered_time_iso = now.isoformat()
+        for c in final:
+            c["reportTriggeredTimeMs"] = report_triggered_time_ms
+            c["reportTriggeredTime"] = report_triggered_time_iso
+
         conf = {"matched_campaigns": final}
 
 
@@ -521,6 +535,14 @@ with DAG(
         run_id,
         )
 
+        for c in final:
+            try:
+                push_status_event(
+                    "SCHEDULED", c, dag_id="hcm_campaign_scheduler", dag_run_id=run_id,
+                    report_triggered_time_ms=report_triggered_time_ms, report_triggered_time=report_triggered_time_iso
+                )
+            except Exception:
+                logger.exception("Failed to push SCHEDULED status event for %s", c.get("campaignIdentifier"))
 
         # TriggerDagRunOperator dynamically created and executed inside Python callable
         trigger_op = TriggerDagRunOperator(

--- a/utilities/airflow-dags/dags/hcm_dynamic_campaigns.py
+++ b/utilities/airflow-dags/dags/hcm_dynamic_campaigns.py
@@ -418,13 +418,14 @@ def compute_range(campaign, now, is_final=False, remaining_days=0):
         try:
             start = datetime.strptime(report_start_date_str, "%d-%m-%Y %H:%M:%S%z")
             end = datetime.strptime(report_end_date_str, "%d-%m-%Y %H:%M:%S%z")
-            # Do NOT convert to UTC here -- it's redundant. The ES filter matches on the
-            # epoch (get_custom_dates_of_reports uses .timestamp()), and the epoch is the
-            # same whether the time is written as +0530 or +0000, so the data returned is
-            # identical either way. The ONLY thing UTC conversion changes is the date we
-            # SHOW: midnight IST becomes the previous evening in UTC (11 Jul 00:00 IST ->
-            # 10 Jul 18:30 UTC), so the user would see the report dated one day before what
-            # they picked. Keeping the selected local time shows the exact dates chosen.
+            # Keep the user-selected timezone instead of converting to UTC.
+            #
+            # Elasticsearch queries are performed using epoch timestamps, so converting
+            # to UTC before calling `.timestamp()` does not change the data returned.
+            # However, converting to UTC changes the displayed date/time (e.g. midnight
+            # IST becomes the previous evening in UTC), which can make report names appear
+            # different from the dates the user selected. Preserving the original timezone
+            # avoids that confusion while producing the same query.
             logger.info("CUSTOM report range: %s to %s", start, end)
             return (start, end)
         except (ValueError, TypeError) as e:

--- a/utilities/airflow-dags/dags/hcm_dynamic_campaigns.py
+++ b/utilities/airflow-dags/dags/hcm_dynamic_campaigns.py
@@ -33,6 +33,9 @@ from airflow.models import Variable
 
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 from kubernetes.client import models as k8s_models
+
+from common.kafka_status import push_status_event
+
 logger = logging.getLogger("airflow.task")
 logger.setLevel(logging.INFO)
 
@@ -59,7 +62,7 @@ K8S_NAMESPACE = os.getenv("K8S_NAMESPACE", "airflow")
 #File store env variables
 FILE_STORE_URL = os.getenv("FILE_STORE_URL") 
 FILE_STORE_UPLOAD_FILE_ENDPOINT = os.getenv("FILE_STORE_UPLOAD_FILE_ENDPOINT", "filestore/v1/files")
-TENANT_ID = os.getenv("TENANT_ID", "dev")
+TENANT_ID = os.getenv("TENANT_ID", "bi")
 MODULE_NAME = os.getenv("FILE_STORE_MODULE_NAME", "custom-reports")
 IS_CENTRAL_INSTANCE_ENABLED = os.getenv("IS_CENTRAL_INSTANCE_ENABLED", "true")
 
@@ -415,9 +418,9 @@ def compute_range(campaign, now, is_final=False, remaining_days=0):
         try:
             start = datetime.strptime(report_start_date_str, "%d-%m-%Y %H:%M:%S%z")
             end = datetime.strptime(report_end_date_str, "%d-%m-%Y %H:%M:%S%z")
-            # Convert to UTC (keep tzinfo so strftime %z produces +0000)
-            start = start.astimezone(timezone.utc)
-            end = end.astimezone(timezone.utc)
+            # Keep the selected local timezone so the displayed range matches what the
+            # user picked (11-15 IST, not 10-14 UTC). ES query is instant-based
+            # (get_custom_dates_of_reports uses .timestamp()), so the window is unchanged.
             logger.info("CUSTOM report range: %s to %s", start, end)
             return (start, end)
         except (ValueError, TypeError) as e:
@@ -501,6 +504,68 @@ def compute_range(campaign, now, is_final=False, remaining_days=0):
     start = to_utc(base_date, start_h, start_m, start_s, start_tz_offset)
     end = to_utc(base_date, end_h, end_m, end_s, end_tz_offset)
     return (start, end)
+
+
+def pod_failure_callback(context):
+    """
+    on_failure_callback for the campaign_pods mapped task.
+
+    Catches Kubernetes-level failures (image pull errors, OOM kill, startup
+    timeout, node eviction) that happen before main.py's own error handling
+    inside the pod ever gets a chance to run, and reports them via the same
+    status pipeline as everything else.
+    """
+    try:
+        ti = context["ti"]
+        map_index = ti.map_index
+        env_list = ti.xcom_pull(task_ids="build_payload") or []
+
+        if map_index is None or map_index < 0 or map_index >= len(env_list):
+            logger.warning(
+                "pod_failure_callback: cannot resolve map_index=%s against %d build_payload entries",
+                map_index, len(env_list)
+            )
+            return
+
+        env_dict = env_list[map_index]
+        campaign_like = {
+            "campaignIdentifier": env_dict.get("CAMPAIGN_IDENTIFIER"),
+            "identifierType": env_dict.get("IDENTIFIER_TYPE"),
+            "reportName": env_dict.get("REPORT_NAME"),
+            "triggerFrequency": env_dict.get("TRIGGER_FREQUENCY"),
+            "triggerTime": env_dict.get("TRIGGER_TIME"),
+            "tenantId": env_dict.get("TENANT_ID"),
+        }
+
+        # env_dict values are all strings (coerced for the K8s API) - parse back to
+        # their real types, defaulting to None on anything empty/unparseable.
+        def _parse_int(raw):
+            try:
+                return int(raw) if raw else None
+            except (TypeError, ValueError):
+                return None
+
+        def _parse_float(raw):
+            try:
+                return float(raw) if raw else None
+            except (TypeError, ValueError):
+                return None
+
+        triggered_ms = _parse_int(env_dict.get("REPORT_TRIGGERED_TIME_MS"))
+
+        push_status_event(
+            "POD_INFRA_FAILED",
+            campaign_like,
+            dag_id=env_dict.get("DAG_ID") or "hcm_dynamic_campaigns",
+            dag_run_id=env_dict.get("DAG_RUN_ID"),
+            error_message=str(context.get("exception")) if context.get("exception") else "Pod execution failed",
+            report_triggered_time_ms=triggered_ms,
+            report_triggered_time=env_dict.get("REPORT_TRIGGERED_TIME") or None,
+            expected_rows=_parse_int(env_dict.get("EXPECTED_ROWS")),
+            expected_generation_time_seconds=_parse_float(env_dict.get("EXPECTED_GENERATION_TIME_SECONDS")),
+        )
+    except Exception:
+        logger.exception("pod_failure_callback itself failed")
 
 
 # ============================
@@ -593,10 +658,29 @@ with DAG(
         env_list = []
         now = datetime.now(UTC)
 
+        # Fallback "actual triggered time" for runs that bypass the scheduler (e.g. a
+        # direct/custom trigger) and therefore never set reportTriggeredTimeMs/
+        # reportTriggeredTime on the incoming campaign dicts. context["dag_run"].start_date
+        # is Airflow's own record of when this run actually started - unlike logical_date,
+        # it can't be set to an arbitrary value by whoever triggered the DAG.
+        fallback_triggered_dt = context["dag_run"].start_date or now
+        fallback_triggered_time_ms = int(fallback_triggered_dt.timestamp() * 1000)
+        fallback_triggered_time_iso = fallback_triggered_dt.isoformat()
+
         for idx, c in enumerate(matches, 1):
             # Required fields - already validated by scheduler DAG
             campaign_identifier = c.get("campaignIdentifier")
             identifier_type = c.get("identifierType")
+            # Prefer the scheduler's stamped value (identical across every row for a
+            # scheduler-initiated run) - fall back to this run's own start_date otherwise.
+            report_triggered_time_ms = c.get("reportTriggeredTimeMs", fallback_triggered_time_ms)
+            report_triggered_time_iso = c.get("reportTriggeredTime", fallback_triggered_time_iso)
+            # Estimates computed once by airflow-trigger-service's trigger_dag (only ever
+            # set for UI-originated CUSTOM runs) - threaded through unchanged, same
+            # "stamp once, carry through" pattern as report_triggered_time_ms, so every
+            # event for this run (including this SKIPPED/TRIGGERED one) carries them.
+            expected_rows = c.get("expectedRows")
+            expected_generation_time_seconds = c.get("expectedGenerationTimeSeconds")
             report_name = c.get("reportName")
             frequency = c.get("triggerFrequency", "Daily")
             report_start_time = c.get("reportStartTime", "00:00:00")
@@ -612,20 +696,37 @@ with DAG(
             logger.info("  Frequency: %s", frequency)
             logger.info("  Report time window: %s to %s", report_start_time, report_end_time)
             logger.info("  Trigger time: %s", trigger_time)
+            logger.info(
+                "  expectedRows=%s expectedGenerationTimeSeconds=%s (from conf.matched_campaigns - "
+                "null here means trigger_dag either didn't set it or this run predates that stamping)",
+                expected_rows, expected_generation_time_seconds,
+            )
             if is_final_report:
                 logger.info("  ⚡ FINAL REPORT: Covering %d remaining days", remaining_days)
 
             # Check if frequency is due (DAILY/WEEKLY/MONTHLY)
             # Final reports bypass frequency check (campaign ending mid-cycle)
             if not is_final_report and not frequency_due(c, now):
-                logger.info("  ⏭️ SKIP: Frequency not due (%s)", frequency)
+                reason = f"Frequency not due ({frequency})"
+                logger.info("  ⏭️ SKIP: %s", reason)
+                push_status_event(
+                    "SKIPPED", c, dag_id=dag_id, dag_run_id=dag_run_id, error_message=reason,
+                    report_triggered_time_ms=report_triggered_time_ms, report_triggered_time=report_triggered_time_iso,
+                    expected_rows=expected_rows, expected_generation_time_seconds=expected_generation_time_seconds,
+                )
                 continue
 
             # Check if first day AND report would cover yesterday's data
             # On first day, only allow if reportEndTime < triggerTime (report covers today)
             # Skip if reportEndTime >= triggerTime (would try to report yesterday before campaign existed)
             if is_first_day(c, now) and not should_report_today(c, now):
-                logger.info("  ⏭️ SKIP: First day and report would cover yesterday (no data exists)")
+                reason = "First day and report would cover yesterday (no data exists)"
+                logger.info("  ⏭️ SKIP: %s", reason)
+                push_status_event(
+                    "SKIPPED", c, dag_id=dag_id, dag_run_id=dag_run_id, error_message=reason,
+                    report_triggered_time_ms=report_triggered_time_ms, report_triggered_time=report_triggered_time_iso,
+                    expected_rows=expected_rows, expected_generation_time_seconds=expected_generation_time_seconds,
+                )
                 continue
 
             # Calculate report date range based on frequency
@@ -635,6 +736,13 @@ with DAG(
             logger.info("  Date range: %s to %s",
                     start_dt.strftime("%Y-%m-%d %H:%M:%S"),
                     end_dt.strftime("%Y-%m-%d %H:%M:%S"))
+
+            # Same string, byte-for-byte, that main.py builds later for this run's own
+            # events (main.py: f"{START_DATE}_{END_DATE}") - computed once here from the
+            # same start_dt/end_dt so the TRIGGERED row's reportRange already matches what
+            # POD_STARTED/REPORT_COMPLETED will show for this same run, instead of being
+            # empty until the pod's own events arrive.
+            report_dates_str = f"{start_dt.strftime('%Y-%m-%d %H:%M:%S%z')}_{end_dt.strftime('%Y-%m-%d %H:%M:%S%z')}"
 
             # Build folder structure for temporary storage
             # Format: /app/REPORTS_GENERATION/FINAL_REPORTS/<campaign_identifier>/<report>/<frequency>/
@@ -660,8 +768,6 @@ with DAG(
 
                 "ELASTIC_PASSWORD": os.getenv("ELASTIC_PASSWORD", ""),
                 "ELASTIC_USERNAME": os.getenv("ELASTIC_USERNAME", "elastic"),
-                # ES host must reach the worker pod (build_payload injects it; common_utils reads ES_HOST)
-                "ES_HOST": os.getenv("ES_HOST", "http://elasticsearch-master.es-cluster.svc.cluster.local:9200"),
 
                 "REPORT_NAME": report_name,
                 "TRIGGER_FREQUENCY": frequency,
@@ -694,6 +800,17 @@ with DAG(
                 "DAG_RUN_ID" : dag_run_id,
                 "DAG_ID" : dag_id,
 
+                # Actual moment this run was triggered (distinct from TRIGGER_TIME, which is
+                # just the configured time-of-day) - same value across every status row for
+                # this run, whether pushed from the DAGs or from inside the pod.
+                "REPORT_TRIGGERED_TIME_MS" : report_triggered_time_ms,
+                "REPORT_TRIGGERED_TIME" : report_triggered_time_iso,
+
+                # Estimates from airflow-trigger-service's trigger_dag (UI-originated CUSTOM
+                # runs only) - threaded through so the pod's own status pushes carry them too.
+                "EXPECTED_ROWS" : expected_rows,
+                "EXPECTED_GENERATION_TIME_SECONDS" : expected_generation_time_seconds,
+
                 #Kafka configurations
                 "CUSTOM_REPORTS_AUTOMATION_TOPIC" : os.getenv("CUSTOM_REPORTS_AUTOMATION_TOPIC"),
                 "KAFKA_BROKER" : os.getenv("KAFKA_BROKER"),
@@ -702,7 +819,20 @@ with DAG(
                 "CREATED_TIME" : c.get("createdTime", "")
             }
 
+            # Kubernetes' EnvVar.value is strictly a string - the K8s API rejects the
+            # entire pod creation (400 Bad Request) if any value is a raw JSON number/bool/null,
+            # which can happen since env_dict pulls some values straight from the DAG run's
+            # conf (untyped, whatever the trigger caller sent). Coerce defensively so a bad
+            # value in one field can never block pod creation for the whole batch.
+            env_dict = {k: ("" if v is None else str(v)) for k, v in env_dict.items()}
+
             env_list.append(env_dict)
+            push_status_event(
+                "TRIGGERED", c, dag_id=dag_id, dag_run_id=dag_run_id,
+                report_triggered_time_ms=report_triggered_time_ms, report_triggered_time=report_triggered_time_iso,
+                expected_rows=expected_rows, expected_generation_time_seconds=expected_generation_time_seconds,
+                report_dates=report_dates_str,
+            )
 
         logger.info("=" * 80)
         logger.info("PAYLOAD BUILT: %d environment configurations", len(env_list))
@@ -777,6 +907,11 @@ with DAG(
             "app": "hcm-reports",
             "managed-by": "airflow"
         },
+
+        # Reports a POD_INFRA_FAILED status event for K8s-level failures (image pull,
+        # OOM kill, startup timeout, node eviction) that never reach main.py's own
+        # error handling inside the pod.
+        on_failure_callback=pod_failure_callback,
 
     ).expand(
         # ✅ CRITICAL: .expand() creates dynamic tasks

--- a/utilities/airflow-dags/dags/hcm_dynamic_campaigns.py
+++ b/utilities/airflow-dags/dags/hcm_dynamic_campaigns.py
@@ -418,9 +418,13 @@ def compute_range(campaign, now, is_final=False, remaining_days=0):
         try:
             start = datetime.strptime(report_start_date_str, "%d-%m-%Y %H:%M:%S%z")
             end = datetime.strptime(report_end_date_str, "%d-%m-%Y %H:%M:%S%z")
-            # Keep the selected local timezone so the displayed range matches what the
-            # user picked (11-15 IST, not 10-14 UTC). ES query is instant-based
-            # (get_custom_dates_of_reports uses .timestamp()), so the window is unchanged.
+            # Do NOT convert to UTC here -- it's redundant. The ES filter matches on the
+            # epoch (get_custom_dates_of_reports uses .timestamp()), and the epoch is the
+            # same whether the time is written as +0530 or +0000, so the data returned is
+            # identical either way. The ONLY thing UTC conversion changes is the date we
+            # SHOW: midnight IST becomes the previous evening in UTC (11 Jul 00:00 IST ->
+            # 10 Jul 18:30 UTC), so the user would see the report dated one day before what
+            # they picked. Keeping the selected local time shows the exact dates chosen.
             logger.info("CUSTOM report range: %s to %s", start, end)
             return (start, end)
         except (ValueError, TypeError) as e:

--- a/utilities/hcm-custom-reports/REPORTS_GENERATION/COMMON_UTILS/localization_utils.py
+++ b/utilities/hcm-custom-reports/REPORTS_GENERATION/COMMON_UTILS/localization_utils.py
@@ -10,8 +10,9 @@ import os
 import re
 import requests
 
-# Fixed module for HCM report-column localizations.
-MODULE = "hcm-dss"
+# Localization module — env-driven like the rest of the config here
+# (ES_HOST/KAFKA_BROKER/LOCALE/TENANT_ID). Defaults to hcm-dss.
+MODULE = os.getenv("LOCALIZATION_MODULE", "hcm-dss")
 
 LOCALIZATION_HOST = os.getenv("LOCALIZATION_HOST", "http://egov-localization.egov.svc.cluster.local:8080")
 LOCALIZATION_SEARCH_ENDPOINT = os.getenv("LOCALIZATION_SEARCH_ENDPOINT", "/localization/messages/v1/_search")

--- a/utilities/hcm-custom-reports/REPORTS_GENERATION/COMMON_UTILS/localization_utils.py
+++ b/utilities/hcm-custom-reports/REPORTS_GENERATION/COMMON_UTILS/localization_utils.py
@@ -1,0 +1,67 @@
+"""
+localization_utils.py
+
+Resolve report column headers to localized text via the egov-localization service.
+Keys follow HCM_<REPORT_DIR>_<COLUMN> under the fixed module 'hcm-dss'. Any failure
+(service unreachable, missing key) falls back to the original English header, so a
+report is never blocked by localization.
+"""
+import os
+import re
+import requests
+
+# Fixed module for HCM report-column localizations.
+MODULE = "hcm-dss"
+
+LOCALIZATION_HOST = os.getenv("LOCALIZATION_HOST", "http://egov-localization.egov.svc.cluster.local:8080")
+LOCALIZATION_SEARCH_ENDPOINT = os.getenv("LOCALIZATION_SEARCH_ENDPOINT", "/localization/messages/v1/_search")
+LOCALE = os.getenv("LOCALE", "en_IN")
+TENANT_ID = os.getenv("TENANT_ID", "")
+
+_messages = None  # lazy cache: {code: message}
+
+
+def _load_messages():
+    global _messages
+    if _messages is not None:
+        return _messages
+    _messages = {}
+    try:
+        url = f"{LOCALIZATION_HOST.rstrip('/')}{LOCALIZATION_SEARCH_ENDPOINT}"
+        params = {"locale": LOCALE, "tenantId": TENANT_ID, "module": MODULE}
+        resp = requests.post(url, params=params, json={"RequestInfo": {}}, timeout=30)
+        if resp.status_code == 200:
+            for m in resp.json().get("messages", []):
+                if m.get("code"):
+                    _messages[m["code"]] = m.get("message")
+            print(f"[LOCALIZATION] loaded {len(_messages)} messages (module={MODULE}, locale={LOCALE}, tenant={TENANT_ID})")
+        else:
+            print(f"[LOCALIZATION] non-200 ({resp.status_code}); falling back to English headers")
+    except Exception as e:
+        print(f"[LOCALIZATION] fetch failed ({e}); falling back to English headers")
+    return _messages
+
+
+def _code_for(report_dir, column):
+    # Must match the key generation: HCM_<REPORT_DIR_UPPER>_<COLUMN alnum-only upper>
+    return f"HCM_{report_dir.upper()}_{re.sub(r'[^A-Za-z0-9]', '', column).upper()}"
+
+
+def localize(code, default=None):
+    """Localized message for a code; falls back to default (or the code itself)."""
+    msg = _load_messages().get(code)
+    return msg if msg else (default if default is not None else code)
+
+
+def localize_headers(report_dir, columns):
+    """Map English column headers to localized headers via HCM_<dir>_<col> keys;
+    falls back to the English header when a key is missing."""
+    return [localize(_code_for(report_dir, c), c) for c in columns]
+
+
+def localize_df_columns(report_dir, df):
+    """Rename a DataFrame's columns to localized headers (in place) via
+    HCM_<dir>_<col> keys. Unmapped columns (e.g. dynamic date/question columns)
+    keep their original name via fallback."""
+    df.rename(columns={c: localize(_code_for(report_dir, c), c) for c in df.columns}, inplace=True)
+    return df

--- a/utilities/hcm-custom-reports/REPORTS_GENERATION/REPORTS/adverse_reactions_report/adverse_reactions_report.py
+++ b/utilities/hcm-custom-reports/REPORTS_GENERATION/REPORTS/adverse_reactions_report/adverse_reactions_report.py
@@ -28,6 +28,7 @@ sys.path.append(file_path)
 # Import custom utility functions
 from COMMON_UTILS.custom_date_utils import get_custom_dates_of_reports
 from COMMON_UTILS.common_utils import get_resp, es_index_url
+from COMMON_UTILS.localization_utils import localize_df_columns
 
 warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made.*")
 
@@ -162,6 +163,7 @@ def generate_report():
 
     # Save to Excel
     output_file = f"{FILE_NAME}.xlsx"
+    localize_df_columns("adverse_reactions_report", df)
     df.to_excel(output_file, index=False)
     print(f"Excel file created: {output_file}")
 

--- a/utilities/hcm-custom-reports/REPORTS_GENERATION/REPORTS/anomaly_report/anomaly_report.py
+++ b/utilities/hcm-custom-reports/REPORTS_GENERATION/REPORTS/anomaly_report/anomaly_report.py
@@ -34,6 +34,7 @@ file_path = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fi
 sys.path.append(file_path)
 from COMMON_UTILS.custom_date_utils import get_custom_dates_of_reports
 from COMMON_UTILS.common_utils import get_resp, es_index_url
+from COMMON_UTILS.localization_utils import localize_df_columns
 
 ES_PROJECT_TASK_SEARCH = es_index_url("project-task-index-v1")
 
@@ -324,6 +325,7 @@ print(df.size)
 
 df_sorted = df.sort_values(by=EXPECTED_COLUMNS, ascending=[True, True, True])
 
+localize_df_columns("anomaly_report", df_sorted)
 df_sorted.to_excel(f"{FILE_NAME}.xlsx", index=False)
 
 e_time = time.time()

--- a/utilities/hcm-custom-reports/REPORTS_GENERATION/REPORTS/attendance_report/attendance_report.py
+++ b/utilities/hcm-custom-reports/REPORTS_GENERATION/REPORTS/attendance_report/attendance_report.py
@@ -32,6 +32,7 @@ sys.path.append(file_path)
 
 from COMMON_UTILS.custom_date_utils import get_custom_dates_of_reports
 from COMMON_UTILS.common_utils import get_resp, es_index_url
+from COMMON_UTILS.localization_utils import localize_df_columns
 
 warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made.*")
 
@@ -273,6 +274,7 @@ for attendee_id, record in attendance_date_map.items():
 
 result = pd.concat(dfs, ignore_index=True)
 
+localize_df_columns("attendance_report", result)
 result.to_excel(f"{FILE_NAME}.xlsx", index=False)
 
 print("Excel file created successfully.")

--- a/utilities/hcm-custom-reports/REPORTS_GENERATION/REPORTS/children_treated_report_updated/children_treated_report_updated.py
+++ b/utilities/hcm-custom-reports/REPORTS_GENERATION/REPORTS/children_treated_report_updated/children_treated_report_updated.py
@@ -30,6 +30,7 @@ warnings.filterwarnings("ignore", message="Unverified HTTPS request is being mad
 
 from COMMON_UTILS.custom_date_utils import get_custom_dates_of_reports
 from COMMON_UTILS.common_utils import get_resp, es_index_url, es_scroll_url
+from COMMON_UTILS.localization_utils import localize_headers
 
 # === CONSTANTS ===
 ES_PROJECT_TASK_INDEX = es_index_url("project-task-index-v1")
@@ -323,7 +324,7 @@ def pass2_stream_to_excel(dup_keys, ind_id_to_name, ind_id_to_head_name, output_
 
     wb = Workbook(write_only=True)
     ws = wb.create_sheet("Sheet1")
-    ws.append(EXPORT_COLUMNS)
+    ws.append(localize_headers("children_treated_report_updated", EXPORT_COLUMNS))
 
     scroll_url  = f"{ES_PROJECT_TASK_INDEX}?scroll=10m"
     scroll_id   = None
@@ -415,7 +416,7 @@ if pass1_total == 0:
     from openpyxl import Workbook
     wb = Workbook(write_only=True)
     ws = wb.create_sheet("Sheet1")
-    ws.append(EXPORT_COLUMNS)
+    ws.append(localize_headers("children_treated_report_updated", EXPORT_COLUMNS))
     output_path = os.path.join(os.getcwd(), f"{FILE_NAME}.xlsx")
     wb.save(output_path)
     print(f"Empty report saved to: {output_path}")

--- a/utilities/hcm-custom-reports/REPORTS_GENERATION/REPORTS/hhr_registered_report/hhr_registered_report.py
+++ b/utilities/hcm-custom-reports/REPORTS_GENERATION/REPORTS/hhr_registered_report/hhr_registered_report.py
@@ -26,6 +26,7 @@ file_path = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__fi
 sys.path.append(file_path)
 
 from COMMON_UTILS.common_utils import get_resp, es_index_url, es_scroll_url
+from COMMON_UTILS.localization_utils import localize_df_columns
 from COMMON_UTILS.custom_date_utils import get_custom_dates_of_reports
 
 warnings.filterwarnings("ignore", message="Unverified HTTPS request is being made.*")
@@ -786,5 +787,6 @@ else:
 file_name = f"{FILE_NAME}.xlsx"
 output_path = os.path.join(os.getcwd(), file_name)
 
+localize_df_columns("hhr_registered_report", df_final)
 df_final.to_excel(output_path, index=False)
 print(f"✅ Detailed registration report generated: {output_path} (Rows: {len(df_final)})")

--- a/utilities/hcm-custom-reports/REPORTS_GENERATION/REPORTS/stock_report/stock_report.py
+++ b/utilities/hcm-custom-reports/REPORTS_GENERATION/REPORTS/stock_report/stock_report.py
@@ -32,6 +32,7 @@ file_path = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.p
 sys.path.append(file_path)
 
 from REPORTS_GENERATION.COMMON_UTILS.custom_date_utils import get_custom_dates_of_reports
+from REPORTS_GENERATION.COMMON_UTILS.localization_utils import localize_headers
 from REPORTS_GENERATION.COMMON_UTILS.common_utils import get_resp, es_index_url, es_scroll_url
 
 # ===========================
@@ -145,7 +146,7 @@ def generate_stock_xlsx():
         "balesQuantity",
         "waybill_quantity"
     ]
-    sheet.append(header)
+    sheet.append(localize_headers("stock_report", header))
 
     local_tz = datetime.now().astimezone().tzinfo
 

--- a/utilities/hcm-custom-reports/main.py
+++ b/utilities/hcm-custom-reports/main.py
@@ -8,6 +8,8 @@ import shutil
 import glob
 import requests
 import zipfile
+import uuid
+import openpyxl
 from confluent_kafka import Producer, KafkaException
 
 
@@ -23,15 +25,39 @@ END_DATE = os.getenv('END_DATE')
 OUTPUT_DIR = os.getenv('OUTPUT_DIR', '/tmp/reports')
 TRIGGER_FREQUENCY = os.getenv('TRIGGER_FREQUENCY', 'DAILY')
 TRIGGER_TIME = os.getenv("TRIGGER_TIME")
-REPORT_FILE_NAME = REPORT_NAME.upper()
 
-FILE_STORE_URL = os.getenv("FILE_STORE_URL") 
+FILE_STORE_URL = os.getenv("FILE_STORE_URL")
 FILE_STORE_UPLOAD_FILE_ENDPOINT = os.getenv("FILE_STORE_UPLOAD_FILE_ENDPOINT", "filestore/v1/files")
 TENANT_ID = os.getenv("TENANT_ID", "dev")
 MODULE_NAME = os.getenv("FILE_STORE_MODULE_NAME", "custom-reports")
 
 DAG_RUN_ID = os.getenv("DAG_RUN_ID")
 DAG_ID = os.getenv("DAG_ID")
+
+# Actual moment this run was triggered (distinct from TRIGGER_TIME, which is just the
+# configured time-of-day) - stamped once upstream (scheduler, or build_payload's own
+# dag_run.start_date for direct/custom triggers) and passed through unchanged so it reads
+# identically across every status row for this run.
+REPORT_TRIGGERED_TIME_MS = os.getenv("REPORT_TRIGGERED_TIME_MS")
+REPORT_TRIGGERED_TIME = os.getenv("REPORT_TRIGGERED_TIME")
+try:
+    REPORT_TRIGGERED_TIME_MS = int(REPORT_TRIGGERED_TIME_MS) if REPORT_TRIGGERED_TIME_MS else None
+except ValueError:
+    REPORT_TRIGGERED_TIME_MS = None
+
+# Estimates computed once by airflow-trigger-service's trigger_dag (UI-originated CUSTOM
+# runs only) - threaded through env vars unchanged, same pattern as REPORT_TRIGGERED_TIME_MS.
+EXPECTED_ROWS = os.getenv("EXPECTED_ROWS")
+try:
+    EXPECTED_ROWS = int(EXPECTED_ROWS) if EXPECTED_ROWS else None
+except ValueError:
+    EXPECTED_ROWS = None
+
+EXPECTED_GENERATION_TIME_SECONDS = os.getenv("EXPECTED_GENERATION_TIME_SECONDS")
+try:
+    EXPECTED_GENERATION_TIME_SECONDS = float(EXPECTED_GENERATION_TIME_SECONDS) if EXPECTED_GENERATION_TIME_SECONDS else None
+except ValueError:
+    EXPECTED_GENERATION_TIME_SECONDS = None
 
 CUSTOM_REPORTS_AUTOMATION_TOPIC = os.getenv("CUSTOM_REPORTS_AUTOMATION_TOPIC", "save-hcm-report-metadata")
 KAFKA_BROKER = os.getenv("KAFKA_BROKER")
@@ -43,11 +69,27 @@ PRODUCER_CONFIG = {
     "debug": "broker,topic,msg",
 }
 
+# Pipeline position per status - lets a status consumer compute "current state" correctly
+# even if events are consumed out of order (a later/more-terminal status always wins).
+STATUS_ORDER = {
+    "SCHEDULED": 10,
+    "TRIGGERED": 20,
+    "SKIPPED": 20,
+    "POD_STARTED": 30,
+    "REPORT_GENERATION_STARTED": 31,
+    "ZIP_STARTED": 32,
+    "FILESTORE_UPLOAD_STARTED": 33,
+    "POD_INFRA_FAILED": 40,
+    "ENV_VALIDATION_FAILED": 40,
+    "REPORT_GENERATION_FAILED": 40,
+    "OUTPUT_NOT_FOUND_FAILED": 40,
+    "ZIP_FAILED": 40,
+    "FILESTORE_UPLOAD_FAILED": 40,
+    "REPORT_COMPLETED": 40,
+}
 
-if not REPORT_NAME or not CAMPAIGN_IDENTIFIER:
-    print('REPORT_NAME and CAMPAIGN_IDENTIFIER are required environment variables')
-    sys.exit(1)
-
+# Producer is built unconditionally (needs only KAFKA_BROKER) so that even a missing
+# required-env-var failure below can be reported via push_report_status.
 producer = Producer(PRODUCER_CONFIG)
 report_duration_seconds = None
 
@@ -89,33 +131,84 @@ def send_to_kafka(producer, topic, message, flush_timeout=10):
     except Exception as e:
         print(f"[KAFKA] ❌ Unexpected error while pushing to topic {topic}: {e}")
 
-def get_data_to_be_pushed(file_store_id, report_duration_seconds=None, status="SUCCESS", error=None):
-    data = {
-        "dag_run_id" : DAG_RUN_ID,
-        "dag_name" : DAG_ID,
-        "campaign_identifier" : CAMPAIGN_IDENTIFIER,
-        "report_name" : REPORT_NAME,
-        "trigger_frequency" : TRIGGER_FREQUENCY,
-        "file_store_id" : file_store_id,
-        "trigger_time" : normalize_timestamp_to_utc(TRIGGER_TIME),
-        "tenant_id" : TENANT_ID,
-        "report_dates" : str(START_DATE) + "_" + str(END_DATE),
-        "report_generation_time_seconds" : report_duration_seconds,
-        "status" : status,
-    }
-    if error:
-        data["error"] = error
-    return data
+def _topic_for(base_topic):
+    """Apply the same tenant-prefixing convention used for every Kafka topic here."""
+    return f"{TENANT_ID}-{base_topic}" if IS_CENTRAL_INSTANCE_ENABLED and TENANT_ID else base_topic
 
-def push_report_status(status, file_store_id="", message=None, exc=None):
+def count_xlsx_rows(file_path):
+    """
+    Best-effort data-row count (excludes the header row) of an xlsx file's active
+    worksheet. Report scripts vary (different report types, occasionally multiple
+    sheets) so this is a rough figure, not an exact cross-report guarantee.
+    Never raises - returns None on any failure so it can never block status reporting.
+    """
+    try:
+        wb = openpyxl.load_workbook(file_path, read_only=True)
+        ws = wb.active
+        count = max(0, (ws.max_row or 1) - 1)
+        wb.close()
+        return count
+    except Exception as e:
+        print(f"[WARN] Failed to count rows in {file_path}: {e}")
+        return None
+
+def build_status_event(status, file_store_id=None, file_size_bytes=None, row_count=None, error=None):
+    """The one payload shape, sent to CUSTOM_REPORTS_AUTOMATION_TOPIC for every status -
+    REPORTS_METADATA is now append-only (one row per status event, not just terminal ones)."""
+    now_dt = datetime.datetime.now(datetime.timezone.utc)
+    timestamp_ms = int(now_dt.timestamp() * 1000)
+    # How long after trigger this specific event happened - gives a per-stage timeline
+    # (e.g. POD_STARTED at +52s, REPORT_COMPLETED at +230s) for every row, not just
+    # completed runs. Mirrors kafka_status.py's push_status_event exactly.
+    seconds_since_triggered = (
+        round((timestamp_ms - REPORT_TRIGGERED_TIME_MS) / 1000, 2)
+        if REPORT_TRIGGERED_TIME_MS is not None else None
+    )
+    return {
+        "event_id": str(uuid.uuid4()),
+        "tenant_id": TENANT_ID,
+        "campaign_identifier": CAMPAIGN_IDENTIFIER,
+        "identifier_type": IDENTIFIER_TYPE,
+        "report_name": REPORT_NAME,
+        "trigger_frequency": TRIGGER_FREQUENCY,
+        # Raw passthrough - matches kafka_status.py's DAG-side events, so this field reads
+        # identically across every status row for the same report run regardless of which
+        # producer sent it.
+        "trigger_time": TRIGGER_TIME,
+        "report_triggered_time_ms": REPORT_TRIGGERED_TIME_MS,
+        "report_triggered_time": REPORT_TRIGGERED_TIME,
+        "expected_rows": EXPECTED_ROWS,
+        "expected_generation_time_seconds": EXPECTED_GENERATION_TIME_SECONDS,
+        "seconds_since_triggered": seconds_since_triggered,
+        "dag_run_id": DAG_RUN_ID,
+        "dag_name": DAG_ID,
+        "status": status,
+        "status_order": STATUS_ORDER.get(status, 0),
+        "error_message": (error or {}).get("message"),
+        "error_type": (error or {}).get("type"),
+        "file_store_id": file_store_id,
+        "file_size_bytes": file_size_bytes,
+        "row_count": row_count,
+        "report_dates": f"{START_DATE}_{END_DATE}",
+        "report_generation_time_seconds": report_duration_seconds,
+        # Epoch millis is the value actually bound into the DB (plain number -> BIGINT,
+        # no JDBC string-to-timestamp cast risk); the ISO string is kept alongside it
+        # purely for human-readable display/debugging.
+        "timestamp_ms": timestamp_ms,
+        "timestamp": now_dt.isoformat(),
+    }
+
+def push_report_status(status, file_store_id="", message=None, exc=None, file_size_bytes=None, row_count=None):
     error = None
     if message or exc:
         error = {"message": message or str(exc)}
         if exc:
             error["type"] = type(exc).__name__
-    kafka_topic = f"{TENANT_ID}-{CUSTOM_REPORTS_AUTOMATION_TOPIC}" if IS_CENTRAL_INSTANCE_ENABLED and TENANT_ID else CUSTOM_REPORTS_AUTOMATION_TOPIC
-    data = get_data_to_be_pushed(file_store_id, report_duration_seconds, status=status, error=error)
-    send_to_kafka(producer=producer, topic=kafka_topic, message=json.dumps(data))
+
+    status_event = build_status_event(
+        status, file_store_id=file_store_id or None, file_size_bytes=file_size_bytes, row_count=row_count, error=error
+    )
+    send_to_kafka(producer=producer, topic=_topic_for(CUSTOM_REPORTS_AUTOMATION_TOPIC), message=json.dumps(status_event))
 
 def get_custom_dates_of_reports():
 
@@ -133,8 +226,6 @@ def get_custom_dates_of_reports():
     print("Reports end date:", end_date)
 
     return printable_start, printable_end
-
-start_date_str, end_date_str = get_custom_dates_of_reports()
 
 def create_zip_of_reports(folder_path, zip_name):
     """
@@ -156,6 +247,7 @@ def create_zip_of_reports(folder_path, zip_name):
                     zipf.write(file_path, arcname)
     except Exception as e:
         print(f"❌ Error creating ZIP file: {e}")
+        push_report_status("ZIP_FAILED", exc=e)
         sys.exit(3)
     print(f"📦 Created ZIP: {zip_path}")
     return zip_path
@@ -207,51 +299,6 @@ def upload_to_filestore(file_path, mime_type="application/zip"):
 
     return resp_json
 
-def normalize_timestamp_to_utc(ts: str) -> str:
-    """
-    Normalize a timestamp string to UTC in the format:
-        DD:MM:YYYY HH:MM:SS+0000
-
-    Accepted input formats:
-    - "DD:MM:YYYY HH:MM:SS+ZZZZ"  (any numeric UTC offset)
-    - "HH:MM:SS+ZZZZ"             (date will be filled with today's UTC date)
-
-    The function:
-    - Parses the input with its given offset
-    - Converts it to UTC
-    - Returns as "DD:MM:YYYY HH:MM:SS+0000"
-    """
-    ts = ts.strip()
-
-    # Try full format: DD:MM:YYYY HH:MM:SS+ZZZZ
-    try:
-        dt = datetime.datetime.strptime(ts, "%d:%m:%Y %H:%M:%S%z")
-    except ValueError:
-        # If that fails, try time-only: HH:MM:SS+ZZZZ
-        try:
-            # Validate and parse time+offset
-            time_only_dt = datetime.datetime.strptime(ts, "%H:%M:%S%z")
-        except ValueError:
-            raise ValueError("Input does not match expected timestamp formats.")
-
-        # Use today's UTC date, combined with the parsed time and original offset
-        today_utc = datetime.datetime.now(datetime.timezone.utc).date()
-        dt = datetime.datetime(
-            year=today_utc.year,
-            month=today_utc.month,
-            day=today_utc.day,
-            hour=time_only_dt.hour,
-            minute=time_only_dt.minute,
-            second=time_only_dt.second,
-            tzinfo=time_only_dt.tzinfo,
-        )
-
-    # Convert to UTC
-    dt_utc = dt.astimezone(datetime.timezone.utc)
-
-    # Format as DD:MM:YYYY HH:MM:SS+0000
-    return dt_utc.strftime("%Y-%m-%d %H:%M:%S")
-
 def save_file_to_folder(file):
     _, extension = os.path.splitext(file)
 
@@ -279,11 +326,28 @@ def save_file_to_folder(file):
     print(f"✅ File saved to: {destination}")
     return destination
 
+# Required-env-var validation happens here (after push_report_status is defined) so a
+# failure can be reported via Kafka instead of crashing unreported.
+if not REPORT_NAME or not CAMPAIGN_IDENTIFIER:
+    print('REPORT_NAME and CAMPAIGN_IDENTIFIER are required environment variables')
+    push_report_status("ENV_VALIDATION_FAILED", message="REPORT_NAME and CAMPAIGN_IDENTIFIER are required environment variables")
+    sys.exit(1)
+
+REPORT_FILE_NAME = REPORT_NAME.upper()
+push_report_status("POD_STARTED")
+
+try:
+    start_date_str, end_date_str = get_custom_dates_of_reports()
+except Exception as e:
+    print(f"Error parsing START_DATE/END_DATE: {e}")
+    push_report_status("ENV_VALIDATION_FAILED", exc=e)
+    sys.exit(1)
+
 original_dir = os.getcwd()
 # input_folder = reports_config["input"]
 # scripts = reports_config["scripts"]
 
-
+report_generation_failed = False
 try:
     print("\n")
     print(f"===== Generating report : {REPORT_NAME}")
@@ -313,6 +377,7 @@ try:
     os.makedirs(OUTPUT_DIR, exist_ok=True)
     os.chdir(OUTPUT_DIR)
 
+    push_report_status("REPORT_GENERATION_STARTED")
     report_start_time = datetime.datetime.now(datetime.timezone.utc)
     subprocess.run(cmd, check=True)
     report_end_time = datetime.datetime.now(datetime.timezone.utc)
@@ -322,67 +387,75 @@ try:
 
 except Exception as e:
     print(f"Error: {e}")
-    push_report_status("FAILED", exc=e)
-    sys.exit(1)
+    push_report_status("REPORT_GENERATION_FAILED", exc=e)
+    report_generation_failed = True
 finally:
-    file_name_substring = REPORT_FILE_NAME
-    move_file = True
-    saved_files = []
-    if move_file:
-        matching_files = glob.glob(f"*{file_name_substring}*")  # Case-sensitive
-        
-        if matching_files:
-            for file_name in matching_files:
-                if os.path.exists(file_name):
-                    saved_path = save_file_to_folder(file_name)
-                    saved_files.append(saved_path)
-                    print(f"Moved file: {file_name}")
+    # Only attempt to move/zip/upload output if the report script actually ran -
+    # otherwise there's nothing valid to package, and doing so risked masking the
+    # real REPORT_GENERATION_FAILED with a later OUTPUT_NOT_FOUND_FAILED/REPORT_COMPLETED.
+    if not report_generation_failed:
+        file_name_substring = REPORT_FILE_NAME
+        move_file = True
+        saved_files = []
+        if move_file:
+            matching_files = glob.glob(f"*{file_name_substring}*")  # Case-sensitive
+
+            if matching_files:
+                for file_name in matching_files:
+                    if os.path.exists(file_name):
+                        saved_path = save_file_to_folder(file_name)
+                        saved_files.append(saved_path)
+                        print(f"Moved file: {file_name}")
+                    else:
+                        print(f"⚠ File not found, skipping: {file_name}")
+            else:
+                print(f"⚠ No files found containing substring: {file_name_substring}")
+                push_report_status("OUTPUT_NOT_FOUND_FAILED", message=f"No output files found for report: {file_name_substring}")
+                report_generation_failed = True
+
+        if not report_generation_failed:
+            reports_folder = os.path.join(
+                OUTPUT_DIR,
+                CAMPAIGN_IDENTIFIER,
+                REPORT_NAME,
+                TRIGGER_FREQUENCY
+            )
+
+            print(f"[DEBUG] Preparing to zip folder: {reports_folder}")
+            print(f"[DEBUG] Folder exists: {os.path.exists(reports_folder)}")
+
+            timestamp = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+            zip_name = f"{REPORT_FILE_NAME}_{CAMPAIGN_IDENTIFIER}_{timestamp}.zip"
+            print(f"[DEBUG] Zip Name: {zip_name}")
+
+            push_report_status("ZIP_STARTED")
+            zip_path = create_zip_of_reports(reports_folder, zip_name)
+
+            print(f"[DEBUG] Zip Path: {zip_path}")
+            # --------------------------------
+            #  UPLOAD ZIP TO FILESTORE SERVICE
+            # --------------------------------
+            try:
+                push_report_status("FILESTORE_UPLOAD_STARTED")
+                upload_response = upload_to_filestore(zip_path)
+                print(f"[DEBUG] FileStore response: {upload_response}")
+
+                if "files" in upload_response and upload_response.get("files"):
+                    file_store_id = upload_response["files"][0].get("fileStoreId")
+                    file_size_bytes = os.path.getsize(zip_path)
+                    xlsx_files = [f for f in saved_files if f.lower().endswith(".xlsx")]
+                    row_count = sum((count_xlsx_rows(f) or 0) for f in xlsx_files) if xlsx_files else None
+                    push_report_status(
+                        "REPORT_COMPLETED", file_store_id=file_store_id,
+                        file_size_bytes=file_size_bytes, row_count=row_count
+                    )
                 else:
-                    print(f"⚠ File not found, skipping: {file_name}")
-        else:
-            print(f"⚠ No files found containing substring: {file_name_substring}")
-            push_report_status("FAILED", message=f"No output files found for report: {file_name_substring}")
-            sys.exit(2)
+                    push_report_status("FILESTORE_UPLOAD_FAILED", message=f"FileStore upload failed: {upload_response}")
 
+            except Exception as e:
+                print(f"❌ Exception while uploading to FileStore: {e}")
+                push_report_status("FILESTORE_UPLOAD_FAILED", message="FileStore upload exception", exc=e)
 
-    reports_folder = os.path.join(
-        OUTPUT_DIR,
-        CAMPAIGN_IDENTIFIER,
-        REPORT_NAME,
-        TRIGGER_FREQUENCY
-    )
+if report_generation_failed:
+    sys.exit(1)
 
-    print(f"[DEBUG] Preparing to zip folder: {reports_folder}")
-    print(f"[DEBUG] Folder exists: {os.path.exists(reports_folder)}")
-    
-    timestamp = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-    zip_name = f"{REPORT_FILE_NAME}_{CAMPAIGN_IDENTIFIER}_{timestamp}.zip"
-# ===========================
-    print(f"[DEBUG] Zip Name: {zip_name}")
-
-    zip_path = create_zip_of_reports(reports_folder, zip_name)
-    
-    print(f"[DEBUG] Zip Path: {zip_path}")
-# ============================
-    # --------------------------------
-    #  UPLOAD ZIP TO FILESTORE SERVICE
-    # --------------------------------
-    try:
-        upload_response = upload_to_filestore(zip_path)
-        print(f"[DEBUG] FileStore response: {upload_response}")
-
-        file_store_id = ""
-
-        if "files" in upload_response:
-            res = upload_response.get("files", [])
-            if len(res) > 0:
-                file_store_id = res[0].get("fileStoreId")
-                push_report_status("SUCCESS", file_store_id=file_store_id)
-        else:
-            push_report_status("FAILED", message=f"FileStore upload failed: {upload_response}")
-
-    except Exception as e:
-        print(f"❌ Exception while uploading to FileStore: {e}")
-        push_report_status("FAILED", message="FileStore upload exception", exc=e)
-
-    


### PR DESCRIPTION
 Brings the config-driven custom-report changes together on top of airflow-analysis:

  Report status lifecycle tracking (from airflow-taraba-enhancements)
  - add common/kafka_status.py: shared push_status_event() that publishes
    SCHEDULED/TRIGGERED/SKIPPED/FAILED/... lifecycle events to
    CUSTOM_REPORTS_AUTOMATION_TOPIC (tenant-prefixed under central instance),
    with a status_order so consumers can compute current state out of order.
  - hcm_campaign_scheduler emits SCHEDULED; hcm_dynamic_campaigns emits
    TRIGGERED/SKIPPED and adds pod_failure_callback so worker-pod failures
    are reported too.
  - main.py emits SUCCESS/FAILED with row count, file size, duration and
    error details; REPORTS_METADATA is now append-only (one row per event).

  Custom-range date fix (one-day-back)
  - compute_range no longer converts the CUSTOM start/end to UTC, so the
    displayed report range reflects the dates the user actually selected
    (e.g. 11-15, not 10-14). The ES query window is unchanged because the
    lookup is timestamp/instant-based.

  Localizable report column headers
  - add COMMON_UTILS/localization_utils.py: resolves headers from
    egov-localization (module "hcm-dss", keys HCM_<REPORT>_<COLUMN>) with a
    safe fallback to the English header if the service or a key is missing.
  - wire it into stock_report, anomaly_report, attendance_report,
    children_treated_report_updated, hhr_registered_report and
    adverse_reactions_report (static headers localized; dynamic date/reason
    columns fall back to their original names)