### PR TITLE
fix(excel-ingestion): restore attendance Register ID auto-fill from boundary

### DIFF
--- a/health-services/excel-ingestion/src/main/java/org/egov/excelingestion/generator/AttendanceRegisterSheetGenerator.java
+++ b/health-services/excel-ingestion/src/main/java/org/egov/excelingestion/generator/AttendanceRegisterSheetGenerator.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.CellType;
 import org.apache.poi.ss.usermodel.Row;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.util.CellReference;
@@ -31,6 +32,9 @@ import java.util.*;
 @Component
 @Slf4j
 public class AttendanceRegisterSheetGenerator implements ISheetGenerator {
+
+    /** Positional format specifier standing in for the Excel row number in a formula template. */
+    private static final String ROW_PLACEHOLDER = "%1$d";
 
     private final BoundaryUtil boundaryUtil;
     private final MDMSService mdmsService;
@@ -88,6 +92,7 @@ public class AttendanceRegisterSheetGenerator implements ISheetGenerator {
                 workbook.createSheet(sheetName);
 
                 // Add boundary dropdowns using HierarchicalBoundaryUtil (same pattern as UserSheetGenerator)
+                HierarchicalBoundaryUtil.BoundaryColumnLayout boundaryLayout = null;
                 if (shouldAddBoundaryDropdowns(generateResource)) {
                     List<CampaignSearchResponse.BoundaryDetail> campaignBoundaries =
                             campaignService.getBoundariesFromCampaign(generateResource.getReferenceId(),
@@ -98,7 +103,7 @@ public class AttendanceRegisterSheetGenerator implements ISheetGenerator {
                                 generateResource.getId(), generateResource.getReferenceId(),
                                 generateResource.getTenantId(), generateResource.getHierarchyType(), requestInfo);
 
-                        hierarchicalBoundaryUtil.addHierarchicalBoundaryColumnWithData(
+                        boundaryLayout = hierarchicalBoundaryUtil.addHierarchicalBoundaryColumnWithData(
                                 workbook, sheetName, localizationMap, enrichedBoundaries,
                                 generateResource.getHierarchyType(), generateResource.getTenantId(),
                                 requestInfo, null);
@@ -109,8 +114,8 @@ public class AttendanceRegisterSheetGenerator implements ISheetGenerator {
                 workbook = (XSSFWorkbook) excelDataPopulator.populateSheetWithData(
                         workbook, sheetName, columns, null, localizationMap);
 
-                // Add Register ID auto-populate formulas
-                addRegisterIdFormulas(workbook, sheetName, generateResource.getHierarchyType());
+                // Must run AFTER populateSheetWithData: the Register ID column only exists by then.
+                addBoundaryCodeAndRegisterIdFormulas(workbook, sheetName, boundaryLayout);
             }
 
         } catch (Exception e) {
@@ -148,108 +153,119 @@ public class AttendanceRegisterSheetGenerator implements ISheetGenerator {
     }
 
     /**
-     * Add Register ID formulas that auto-populate from the rightmost non-empty boundary column.
-     * Formula: IF(lastBoundary<>"", lastBoundary, IF(secondLast<>"", secondLast, ...))
-     * Uses unlocked cell style so users can manually override.
+     * Attendance-register only: fills the hidden boundary-code column with a per-row lookup so the
+     * Register ID (a plain reference to it) auto-populates in Excel the moment a boundary is picked.
+     *
+     * The shared boundary util deliberately writes no per-row formulas — templates that do not need
+     * this live auto-fill (facility / user / unified-console) stay scaffold-less. The helper columns
+     * the pre-scaffold-removal design used are not recreated either: the cascade now resolves inside
+     * each validation formula, so only this one lookup column is needed.
+     *
+     * Blank until a boundary is selected, and left unlocked so a user can type their own id over it.
+     * Rows past excelRowLimit keep a blank code, which BoundaryCodeResolver fills on upload.
      */
-    private void addRegisterIdFormulas(XSSFWorkbook workbook, String sheetName, String hierarchyType) {
+    private void addBoundaryCodeAndRegisterIdFormulas(XSSFWorkbook workbook, String sheetName,
+                                                      HierarchicalBoundaryUtil.BoundaryColumnLayout layout) {
+        if (layout == null || layout.getCodeMappingStartRow() < 1) {
+            log.info("No boundary code mapping available, skipping attendance register formulas");
+            return;
+        }
+
         Sheet sheet = workbook.getSheet(sheetName);
-        if (sheet == null) return;
+        Row hiddenRow = sheet != null ? sheet.getRow(0) : null;
+        if (hiddenRow == null) {
+            log.warn("Hidden header row missing on sheet {}, skipping attendance register formulas", sheetName);
+            return;
+        }
 
-        Row hiddenRow = sheet.getRow(0);
-        if (hiddenRow == null) return;
-
-        // Find boundary code column, visible boundary columns, and Register ID column from hidden row 0
-        String hierarchyPrefix = hierarchyType != null ? hierarchyType.toUpperCase() + "_" : "";
-        List<Integer> visibleBoundaryColIndices = new ArrayList<>();
         int registerIdColIndex = -1;
-        int boundaryCodeColIndex = -1;
-
-        for (int colIdx = 0; colIdx <= hiddenRow.getLastCellNum(); colIdx++) {
+        // getLastCellNum() is already lastIndex + 1; a non-string header would throw on getStringCellValue.
+        for (int colIdx = 0; colIdx < hiddenRow.getLastCellNum(); colIdx++) {
             Cell cell = hiddenRow.getCell(colIdx);
-            if (cell == null) continue;
-            String cellValue = cell.getStringCellValue();
-            if (cellValue == null) continue;
-
-            // Check if it's a visible boundary column (has hierarchy prefix, not hidden, not a helper)
-            if (!hierarchyPrefix.isEmpty() && cellValue.startsWith(hierarchyPrefix)
-                    && !cellValue.endsWith("_HELPER") && !sheet.isColumnHidden(colIdx)) {
-                visibleBoundaryColIndices.add(colIdx);
-            }
-
-            // Check for Register ID column
-            if (ProcessingConstants.REGISTER_ID_COLUMN_KEY.equals(cellValue)) {
+            if (cell != null && cell.getCellType() == CellType.STRING
+                    && ProcessingConstants.REGISTER_ID_COLUMN_KEY.equals(cell.getStringCellValue())) {
                 registerIdColIndex = colIdx;
-            }
-
-            // Check for boundary code column (hidden column with VLOOKUP result)
-            if (ProcessingConstants.BOUNDARY_CODE_COLUMN_KEY.equals(cellValue)) {
-                boundaryCodeColIndex = colIdx;
+                break;
             }
         }
-
         if (registerIdColIndex == -1) {
-            log.info("Register ID column not found, skipping formula generation");
+            log.info("Register ID column not found, skipping attendance register formulas");
             return;
         }
 
-        if (boundaryCodeColIndex == -1 && visibleBoundaryColIndices.isEmpty()) {
-            log.info("Neither boundary code column nor visible boundary columns found, skipping formula generation");
+        List<Integer> levelCols = layout.getVisibleBoundaryColIndices();
+        if (levelCols.isEmpty()) {
+            log.info("No visible boundary columns found, skipping attendance register formulas");
             return;
         }
 
-        // Create unlocked cell style for formula cells (users can override)
+        int codeColIndex = layout.getBoundaryCodeColIndex();
+        String codeColLetter = CellReference.convertNumToColString(codeColIndex);
+        String mappingRange = String.format("%s!$%s$%d:$%s$%d",
+                HierarchicalBoundaryUtil.LOOKUP_SHEET_NAME,
+                CellReference.convertNumToColString(HierarchicalBoundaryUtil.CODE_MAPPING_KEY_COLUMN),
+                layout.getCodeMappingStartRow(),
+                CellReference.convertNumToColString(HierarchicalBoundaryUtil.CODE_MAPPING_CODE_COLUMN),
+                layout.getCodeMappingEndRow());
+
+        int lastRow = config.getExcelRowLimit();
+
         CellStyle unlocked = workbook.createCellStyle();
         unlocked.setLocked(false);
 
-        int maxRow = config.getExcelRowLimit();
+        // Only the row number varies per row, so build the nested formula once and stamp the row in.
+        String codeFormulaTemplate = buildBoundaryCodeFormulaTemplate(levelCols, mappingRange);
 
-        // Apply formula to data rows (row 2 onwards, 0-indexed)
-        for (int r = 2; r <= maxRow; r++) {
+        for (int r = 2; r <= lastRow; r++) {
             Row row = sheet.getRow(r);
             if (row == null) row = sheet.createRow(r);
 
-            Cell registerIdCell = row.getCell(registerIdColIndex, Row.MissingCellPolicy.CREATE_NULL_AS_BLANK);
+            row.getCell(codeColIndex, Row.MissingCellPolicy.CREATE_NULL_AS_BLANK)
+                    .setCellFormula(String.format(codeFormulaTemplate, r + 1));
 
-            String formula;
-            if (boundaryCodeColIndex != -1) {
-                // Reference the hidden boundary code column directly (contains boundary code via VLOOKUP)
-                formula = CellReference.convertNumToColString(boundaryCodeColIndex) + (r + 1);
-            } else {
-                // Fallback: build nested IF over visible boundary display-name columns
-                formula = buildRegisterIdFormula(r + 1, visibleBoundaryColIndices);
-            }
-            registerIdCell.setCellFormula(formula);
+            Cell registerIdCell = row.getCell(registerIdColIndex, Row.MissingCellPolicy.CREATE_NULL_AS_BLANK);
+            registerIdCell.setCellFormula(codeColLetter + (r + 1));
             registerIdCell.setCellStyle(unlocked);
         }
 
-        log.info("Added Register ID formulas for {} rows using {} source",
-                maxRow - 1, boundaryCodeColIndex != -1 ? "boundary code column" : "visible boundary columns");
+        log.info("Added attendance register boundary-code + Register ID formulas for rows 3-{} (mapping {})",
+                lastRow + 1, mappingRange);
     }
 
     /**
-     * Build nested IF formula: IF(lastCol<>"", lastCol, IF(secondLastCol<>"", secondLastCol, ...))
-     * Checks from rightmost to leftmost visible boundary column.
+     * Resolves the deepest selected boundary level to its code:
+     * IF(deepest<>"", VLOOKUP(path-to-deepest, mapping, codeOffset, 0), IF(nextUp<>"", ... , "")).
+     * Empty when no level is selected, and IFERROR keeps an out-of-dropdown value blank rather than #N/A.
+     *
+     * Returned as a format template with {@value #ROW_PLACEHOLDER} wherever the row number goes; every
+     * other fragment is an internal constant or a column letter, so no stray format specifiers appear.
      */
-    private String buildRegisterIdFormula(int excelRowNumber, List<Integer> visibleBoundaryColIndices) {
+    private String buildBoundaryCodeFormulaTemplate(List<Integer> levelCols, String mappingRange) {
+        // VLOOKUP's result index is the code column's 1-based offset WITHIN the mapping range, so it
+        // must be derived from the two mapping constants rather than assuming they are adjacent.
+        int codeColumnOffset = HierarchicalBoundaryUtil.CODE_MAPPING_CODE_COLUMN
+                - HierarchicalBoundaryUtil.CODE_MAPPING_KEY_COLUMN + 1;
+
         StringBuilder formula = new StringBuilder();
         int nestCount = 0;
 
-        // Iterate from rightmost to leftmost
-        for (int i = visibleBoundaryColIndices.size() - 1; i >= 0; i--) {
-            String colRef = CellReference.convertNumToColString(visibleBoundaryColIndices.get(i)) + excelRowNumber;
-            formula.append("IF(").append(colRef).append("<>\"\",").append(colRef).append(",");
+        for (int i = levelCols.size() - 1; i >= 0; i--) {
+            String levelRef = CellReference.convertNumToColString(levelCols.get(i)) + ROW_PLACEHOLDER;
+            StringBuilder path = new StringBuilder();
+            for (int j = 0; j <= i; j++) {
+                if (j > 0) path.append(",\"").append(HierarchicalBoundaryUtil.BOUNDARY_SEPARATOR).append("\",");
+                path.append(CellReference.convertNumToColString(levelCols.get(j))).append(ROW_PLACEHOLDER);
+            }
+            formula.append("IF(").append(levelRef).append("<>\"\",IFERROR(VLOOKUP(CONCATENATE(")
+                    .append(path).append("),").append(mappingRange).append(",")
+                    .append(codeColumnOffset).append(",0),\"\"),");
             nestCount++;
         }
 
-        // Innermost: return empty string when no boundary is filled
         formula.append("\"\"");
-
-        // Close all IF parentheses
         for (int i = 0; i < nestCount; i++) {
             formula.append(")");
         }
-
         return formula.toString();
     }
 }

--- a/health-services/excel-ingestion/src/main/java/org/egov/excelingestion/generator/AttendanceRegisterSheetGenerator.java
+++ b/health-services/excel-ingestion/src/main/java/org/egov/excelingestion/generator/AttendanceRegisterSheetGenerator.java
@@ -162,7 +162,11 @@ public class AttendanceRegisterSheetGenerator implements ISheetGenerator {
      * each validation formula, so only this one lookup column is needed.
      *
      * Blank until a boundary is selected, and left unlocked so a user can type their own id over it.
-     * Rows past excelRowLimit keep a blank code, which BoundaryCodeResolver fills on upload.
+     *
+     * The fill must span the same rows as the dropdown validations (index 2..excelRowLimit + 1) — a
+     * dropdown row without the formula yields a blank code, and project-factory rejects that row with
+     * "Boundary code is missing". There is no server-side recovery for this template: attendance
+     * uploads are parsed by project-factory itself, so BoundaryCodeResolver never runs on them.
      */
     private void addBoundaryCodeAndRegisterIdFormulas(XSSFWorkbook workbook, String sheetName,
                                                       HierarchicalBoundaryUtil.BoundaryColumnLayout layout) {
@@ -208,7 +212,9 @@ public class AttendanceRegisterSheetGenerator implements ISheetGenerator {
                 CellReference.convertNumToColString(HierarchicalBoundaryUtil.CODE_MAPPING_CODE_COLUMN),
                 layout.getCodeMappingEndRow());
 
-        int lastRow = config.getExcelRowLimit();
+        // Matches the cascade validation range (HierarchicalBoundaryUtil applies dropdowns to
+        // 2..excelRowLimit + 1), so every row that offers a dropdown can resolve its code.
+        int lastRow = config.getExcelRowLimit() + 1;
 
         CellStyle unlocked = workbook.createCellStyle();
         unlocked.setLocked(false);
@@ -220,12 +226,20 @@ public class AttendanceRegisterSheetGenerator implements ISheetGenerator {
             Row row = sheet.getRow(r);
             if (row == null) row = sheet.createRow(r);
 
-            row.getCell(codeColIndex, Row.MissingCellPolicy.CREATE_NULL_AS_BLANK)
-                    .setCellFormula(String.format(codeFormulaTemplate, r + 1));
+            // Only ever fill blanks: a prefilled row's code/id is server-authoritative.
+            Cell codeCell = row.getCell(codeColIndex, Row.MissingCellPolicy.CREATE_NULL_AS_BLANK);
+            if (codeCell.getCellType() == CellType.BLANK) {
+                codeCell.setCellFormula(String.format(codeFormulaTemplate, r + 1));
+            }
 
             Cell registerIdCell = row.getCell(registerIdColIndex, Row.MissingCellPolicy.CREATE_NULL_AS_BLANK);
-            registerIdCell.setCellFormula(codeColLetter + (r + 1));
-            registerIdCell.setCellStyle(unlocked);
+            if (registerIdCell.getCellType() == CellType.BLANK) {
+                // Guarded rather than a bare reference: =<code><row> on a blank code cell renders 0,
+                // which was the reported symptom.
+                String codeRef = codeColLetter + (r + 1);
+                registerIdCell.setCellFormula("IF(" + codeRef + "=\"\",\"\"," + codeRef + ")");
+                registerIdCell.setCellStyle(unlocked);
+            }
         }
 
         log.info("Added attendance register boundary-code + Register ID formulas for rows 3-{} (mapping {})",

--- a/health-services/excel-ingestion/src/main/java/org/egov/excelingestion/util/HierarchicalBoundaryUtil.java
+++ b/health-services/excel-ingestion/src/main/java/org/egov/excelingestion/util/HierarchicalBoundaryUtil.java
@@ -1,5 +1,6 @@
 package org.egov.excelingestion.util;
 
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.ss.util.CellRangeAddressList;
@@ -32,7 +33,10 @@ import java.util.stream.Collectors;
  *   needed for the lookup itself.
  * - The hidden boundary-code column carries VALUES only for prefilled rows; codes for user-entered
  *   rows are resolved server-side on upload ({@link BoundaryCodeResolver}) from the same lookup
- *   sheet's display-path-to-code mapping, so no per-row VLOOKUP formulas exist either.
+ *   sheet's display-path-to-code mapping, so this util writes no per-row VLOOKUP formulas either.
+ *   (The attendance-register template is the one exception: it needs the code live in the sheet so
+ *   Register ID auto-fills on selection, so its generator adds that lookup itself from the range
+ *   reported in {@link BoundaryColumnLayout} — deliberately not here, to keep other templates flat.)
  * This keeps the generated file size and open/parse cost independent of the row limit (previously
  * ~6 formulas x rowLimit x 2 sheets made 20k-row templates multi-MB, slow to open, and truncated
  * to 1000 scaffold rows by a LibreOffice save).
@@ -104,10 +108,10 @@ public class HierarchicalBoundaryUtil {
      * Adds cascading boundary dropdown columns to an existing sheet
      * Creates multiple columns starting from 1st level with cascading dropdowns
      */
-    public void addHierarchicalBoundaryColumn(XSSFWorkbook workbook, String sheetName, Map<String, String> localizationMap,
+    public BoundaryColumnLayout addHierarchicalBoundaryColumn(XSSFWorkbook workbook, String sheetName, Map<String, String> localizationMap,
                                               List<Boundary> configuredBoundaries, String hierarchyType,
                                               String tenantId, RequestInfo requestInfo) {
-        addHierarchicalBoundaryColumnWithData(workbook, sheetName, localizationMap, configuredBoundaries,
+        return addHierarchicalBoundaryColumnWithData(workbook, sheetName, localizationMap, configuredBoundaries,
                 hierarchyType, tenantId, requestInfo, null);
     }
 
@@ -116,18 +120,18 @@ public class HierarchicalBoundaryUtil {
      * Creates multiple columns starting from 1st level with cascading dropdowns
      * If existingData is provided, populates the first rows with that data
      */
-    public void addHierarchicalBoundaryColumnWithData(XSSFWorkbook workbook, String sheetName, Map<String, String> localizationMap,
+    public BoundaryColumnLayout addHierarchicalBoundaryColumnWithData(XSSFWorkbook workbook, String sheetName, Map<String, String> localizationMap,
                                                       List<Boundary> configuredBoundaries, String hierarchyType,
                                                       String tenantId, RequestInfo requestInfo, List<Map<String, Object>> existingData) {
         Sheet sheet = workbook.getSheet(sheetName);
         if (sheet == null) {
             log.warn("Sheet '{}' not found, cannot add hierarchical boundary column", sheetName);
-            return;
+            return null;
         }
 
         if (configuredBoundaries == null || configuredBoundaries.isEmpty()) {
             log.info("No boundaries configured for sheet '{}', skipping boundary column creation", sheetName);
-            return;
+            return null;
         }
 
         // Fetch boundary relationship data
@@ -138,7 +142,7 @@ public class HierarchicalBoundaryUtil {
         BoundaryHierarchyResponse hierarchyData = boundaryService.fetchBoundaryHierarchy(tenantId, hierarchyType, requestInfo);
         if (hierarchyData == null || hierarchyData.getBoundaryHierarchy() == null || hierarchyData.getBoundaryHierarchy().isEmpty()) {
             log.error("Boundary hierarchy data is null or empty for type: {}", hierarchyType);
-            return;
+            return null;
         }
 
         List<BoundaryHierarchyChild> hierarchyRelations = hierarchyData.getBoundaryHierarchy().get(0).getBoundaryHierarchy();
@@ -148,7 +152,7 @@ public class HierarchicalBoundaryUtil {
 
         if (levelTypes.size() < 1) {
             log.warn("Hierarchy has less than 1 level, skipping boundary column creation");
-            return;
+            return null;
         }
 
         List<BoundaryUtil.BoundaryRowData> filteredBoundaries = boundaryUtil.processBoundariesWithEnrichment(
@@ -156,7 +160,7 @@ public class HierarchicalBoundaryUtil {
 
         if (filteredBoundaries.isEmpty()) {
             log.info("No boundaries available for sheet '{}', skipping boundary column creation", sheetName);
-            return;
+            return null;
         }
 
         Row hiddenRow = sheet.getRow(0);
@@ -244,6 +248,9 @@ public class HierarchicalBoundaryUtil {
         sheet.setDefaultColumnStyle(boundaryCodeColIndex, formulaStyle);
 
         log.info("Added {} cascading boundary dropdown columns (no per-row scaffold).", levelTypes.size());
+
+        return new BoundaryColumnLayout(boundaryCodeColIndex, visibleColIndices,
+                mappingResult.codeMappingStartRow, mappingResult.codeMappingEndRow);
     }
 
     /**
@@ -417,7 +424,9 @@ public class HierarchicalBoundaryUtil {
         log.info("Created cascading boundary lookup sheet: {} children rows, {} display-name mappings (rows {}-{})",
                 childrenSectionEndRow, comboToCodeMap.size(), displayNameMappingStartRow + 1, displayNameMappingEndRow);
 
-        return new ParentChildrenMapping(parentChildrenMap, childrenSectionEndRow);
+        return new ParentChildrenMapping(parentChildrenMap, childrenSectionEndRow,
+                comboToCodeMap.isEmpty() ? 0 : displayNameMappingStartRow + 1,
+                comboToCodeMap.isEmpty() ? 0 : displayNameMappingEndRow);
     }
 
     /**
@@ -427,10 +436,41 @@ public class HierarchicalBoundaryUtil {
         final Map<String, Set<String>> parentChildrenMap;
         /** Number of Section-1 rows: the MATCH range of every cascade validation is $A$1:$A$<this>. */
         final int childrenSectionEndRow;
+        /** 1-based inclusive row bounds of Section 2 (display-path -> code). 0 when empty. */
+        final int codeMappingStartRow;
+        final int codeMappingEndRow;
 
-        ParentChildrenMapping(Map<String, Set<String>> parentChildrenMap, int childrenSectionEndRow) {
+        ParentChildrenMapping(Map<String, Set<String>> parentChildrenMap, int childrenSectionEndRow,
+                              int codeMappingStartRow, int codeMappingEndRow) {
             this.parentChildrenMap = parentChildrenMap;
             this.childrenSectionEndRow = childrenSectionEndRow;
+            this.codeMappingStartRow = codeMappingStartRow;
+            this.codeMappingEndRow = codeMappingEndRow;
+        }
+    }
+
+    /**
+     * Layout of the boundary columns a generator just had added, so a caller can attach its own
+     * per-row formulas without re-deriving column positions or the lookup sheet's section bounds.
+     * Deliberately data-only: no formulas are written here, so templates that do not ask for them
+     * (facility / user / unified-console) are unaffected.
+     */
+    @Getter
+    public static class BoundaryColumnLayout {
+        private final int boundaryCodeColIndex;
+        private final List<Integer> visibleBoundaryColIndices;
+        /** 1-based inclusive row bounds of the display-path -> code mapping; 0 when there is none. */
+        private final int codeMappingStartRow;
+        private final int codeMappingEndRow;
+
+        public BoundaryColumnLayout(int boundaryCodeColIndex, List<Integer> visibleBoundaryColIndices,
+                                    int codeMappingStartRow, int codeMappingEndRow) {
+            this.boundaryCodeColIndex = boundaryCodeColIndex;
+            // Copy: the caller hands over its live working list, and this layout is a value.
+            this.visibleBoundaryColIndices = visibleBoundaryColIndices == null
+                    ? List.of() : List.copyOf(visibleBoundaryColIndices);
+            this.codeMappingStartRow = codeMappingStartRow;
+            this.codeMappingEndRow = codeMappingEndRow;
         }
     }
 

--- a/health-services/excel-ingestion/src/test/java/org/egov/excelingestion/generator/AttendanceRegisterSheetGeneratorTest.java
+++ b/health-services/excel-ingestion/src/test/java/org/egov/excelingestion/generator/AttendanceRegisterSheetGeneratorTest.java
@@ -1,0 +1,246 @@
+package org.egov.excelingestion.generator;
+
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.ss.usermodel.FormulaEvaluator;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.egov.excelingestion.config.ExcelIngestionConfig;
+import org.egov.excelingestion.config.ProcessingConstants;
+import org.egov.excelingestion.util.HierarchicalBoundaryUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+
+/**
+ * The attendance register sheet auto-fills Register ID from the boundary the user selects, so the
+ * hidden code column carries a per-row lookup and Register ID references it. Formulas are actually
+ * EVALUATED here (POI FormulaEvaluator) rather than string-matched, so the test proves the observable
+ * behaviour: blank until a boundary is picked, the boundary's code once it is.
+ */
+@ExtendWith(MockitoExtension.class)
+class AttendanceRegisterSheetGeneratorTest {
+
+    @Mock
+    private ExcelIngestionConfig config;
+
+    private static final String SHEET = "Attendance Registers";
+    private static final int COUNTRY_COL = 0;
+    private static final int STATE_COL = 1;
+    private static final int CODE_COL = 2;
+    private static final int REGISTER_ID_COL = 3;
+
+    // Section-2 mapping rows on the lookup sheet (1-based, as the layout reports them)
+    private static final int MAPPING_START = 5;
+    private static final int MAPPING_END = 6;
+
+    private static final String COUNTRY_CODE = "HIER_NG";
+    private static final String STATE_CODE = "HIER_NG_02_OYO";
+
+    private AttendanceRegisterSheetGenerator newGenerator() {
+        return new AttendanceRegisterSheetGenerator(null, null, null, null, null, null, null, config);
+    }
+
+    private HierarchicalBoundaryUtil.BoundaryColumnLayout layout() {
+        return new HierarchicalBoundaryUtil.BoundaryColumnLayout(
+                CODE_COL, Arrays.asList(COUNTRY_COL, STATE_COL), MAPPING_START, MAPPING_END);
+    }
+
+    private void invoke(XSSFWorkbook wb, HierarchicalBoundaryUtil.BoundaryColumnLayout layout) throws Exception {
+        Method m = AttendanceRegisterSheetGenerator.class.getDeclaredMethod(
+                "addBoundaryCodeAndRegisterIdFormulas", XSSFWorkbook.class, String.class,
+                HierarchicalBoundaryUtil.BoundaryColumnLayout.class);
+        m.setAccessible(true);
+        m.invoke(newGenerator(), wb, SHEET, layout);
+    }
+
+    /** Register sheet with the hidden key row, plus the lookup sheet's display-path -> code mapping. */
+    private XSSFWorkbook workbookWithLayout() {
+        XSSFWorkbook wb = new XSSFWorkbook();
+        Sheet sheet = wb.createSheet(SHEET);
+        Row hidden = sheet.createRow(0);
+        hidden.createCell(COUNTRY_COL).setCellValue("HIER_COUNTRY");
+        hidden.createCell(STATE_COL).setCellValue("HIER_STATE");
+        hidden.createCell(CODE_COL).setCellValue(ProcessingConstants.BOUNDARY_CODE_COLUMN_KEY);
+        hidden.createCell(REGISTER_ID_COL).setCellValue(ProcessingConstants.REGISTER_ID_COLUMN_KEY);
+
+        Sheet lookup = wb.createSheet(HierarchicalBoundaryUtil.LOOKUP_SHEET_NAME);
+        Row m1 = lookup.createRow(MAPPING_START - 1);
+        m1.createCell(HierarchicalBoundaryUtil.CODE_MAPPING_KEY_COLUMN).setCellValue("Nigeria");
+        m1.createCell(HierarchicalBoundaryUtil.CODE_MAPPING_CODE_COLUMN).setCellValue(COUNTRY_CODE);
+        Row m2 = lookup.createRow(MAPPING_END - 1);
+        m2.createCell(HierarchicalBoundaryUtil.CODE_MAPPING_KEY_COLUMN).setCellValue("Nigeria#Oyo");
+        m2.createCell(HierarchicalBoundaryUtil.CODE_MAPPING_CODE_COLUMN).setCellValue(STATE_CODE);
+        return wb;
+    }
+
+    private void stubRowLimit(int rowLimit) {
+        lenient().when(config.getExcelRowLimit()).thenReturn(rowLimit);
+    }
+
+    private String evaluatedString(FormulaEvaluator evaluator, Cell cell) {
+        return evaluator.evaluate(cell).getStringValue();
+    }
+
+    @Test
+    void registerIdResolvesToTheDeepestSelectedBoundaryCode() throws Exception {
+        stubRowLimit(5000);
+        try (XSSFWorkbook wb = workbookWithLayout()) {
+            invoke(wb, layout());
+
+            Sheet sheet = wb.getSheet(SHEET);
+            Row row = sheet.getRow(2); // Excel row 3
+            row.createCell(COUNTRY_COL).setCellValue("Nigeria");
+            row.createCell(STATE_COL).setCellValue("Oyo");
+
+            FormulaEvaluator evaluator = wb.getCreationHelper().createFormulaEvaluator();
+            assertEquals(STATE_CODE, evaluatedString(evaluator, row.getCell(CODE_COL)));
+            assertEquals(STATE_CODE, evaluatedString(evaluator, row.getCell(REGISTER_ID_COL)));
+        }
+    }
+
+    @Test
+    void registerIdResolvesToTheParentCodeWhenOnlyTheTopLevelIsSelected() throws Exception {
+        stubRowLimit(5000);
+        try (XSSFWorkbook wb = workbookWithLayout()) {
+            invoke(wb, layout());
+
+            Row row = wb.getSheet(SHEET).getRow(2);
+            row.createCell(COUNTRY_COL).setCellValue("Nigeria");
+
+            FormulaEvaluator evaluator = wb.getCreationHelper().createFormulaEvaluator();
+            assertEquals(COUNTRY_CODE, evaluatedString(evaluator, row.getCell(REGISTER_ID_COL)));
+        }
+    }
+
+    @Test
+    void registerIdIsBlankWhenNoBoundaryIsSelected() throws Exception {
+        stubRowLimit(5000);
+        try (XSSFWorkbook wb = workbookWithLayout()) {
+            invoke(wb, layout());
+
+            Row row = wb.getSheet(SHEET).getRow(2);
+            FormulaEvaluator evaluator = wb.getCreationHelper().createFormulaEvaluator();
+            // The reported regression was a bare reference rendering as 0 - it must be "" instead.
+            assertEquals("", evaluatedString(evaluator, row.getCell(CODE_COL)));
+            assertEquals("", evaluatedString(evaluator, row.getCell(REGISTER_ID_COL)));
+        }
+    }
+
+    @Test
+    void anOutOfDropdownSelectionLeavesTheCodeBlankRatherThanErroring() throws Exception {
+        stubRowLimit(5000);
+        try (XSSFWorkbook wb = workbookWithLayout()) {
+            invoke(wb, layout());
+
+            Row row = wb.getSheet(SHEET).getRow(2);
+            row.createCell(COUNTRY_COL).setCellValue("Atlantis");
+
+            FormulaEvaluator evaluator = wb.getCreationHelper().createFormulaEvaluator();
+            assertEquals("", evaluatedString(evaluator, row.getCell(CODE_COL)));
+        }
+    }
+
+    @Test
+    void registerIdCellStaysUnlockedSoTheUserCanOverrideIt() throws Exception {
+        stubRowLimit(5000);
+        try (XSSFWorkbook wb = workbookWithLayout()) {
+            invoke(wb, layout());
+
+            Cell registerId = wb.getSheet(SHEET).getRow(2).getCell(REGISTER_ID_COL);
+            assertFalse(registerId.getCellStyle().getLocked(), "Register ID must remain user-editable");
+        }
+    }
+
+    @Test
+    void fillSpansTheConfiguredExcelRowLimit() throws Exception {
+        stubRowLimit(10);
+        try (XSSFWorkbook wb = workbookWithLayout()) {
+            invoke(wb, layout());
+
+            Sheet sheet = wb.getSheet(SHEET);
+            assertEquals(CellType.FORMULA, sheet.getRow(2).getCell(REGISTER_ID_COL).getCellType());
+            assertEquals(CellType.FORMULA, sheet.getRow(10).getCell(REGISTER_ID_COL).getCellType());
+            assertNull(sheet.getRow(11), "fill must stop at excelRowLimit");
+        }
+    }
+
+    @Test
+    void noFormulasAreWrittenWhenThereIsNoBoundaryCodeMapping() throws Exception {
+        try (XSSFWorkbook wb = workbookWithLayout()) {
+            invoke(wb, new HierarchicalBoundaryUtil.BoundaryColumnLayout(
+                    CODE_COL, Arrays.asList(COUNTRY_COL, STATE_COL), 0, 0));
+
+            assertNull(wb.getSheet(SHEET).getRow(2), "an empty mapping must leave the sheet untouched");
+        }
+    }
+
+    @Test
+    void noFormulasAreWrittenWhenTheLayoutIsAbsent() throws Exception {
+        try (XSSFWorkbook wb = workbookWithLayout()) {
+            invoke(wb, null);
+            assertNull(wb.getSheet(SHEET).getRow(2), "a null layout must leave the sheet untouched");
+        }
+    }
+
+    @Test
+    void noFormulasAreWrittenWhenTheRegisterIdColumnIsMissing() throws Exception {
+        try (XSSFWorkbook wb = workbookWithLayout()) {
+            wb.getSheet(SHEET).getRow(0).getCell(REGISTER_ID_COL).setCellValue("SOMETHING_ELSE");
+            invoke(wb, layout());
+            assertNull(wb.getSheet(SHEET).getRow(2), "a missing Register ID column must be a no-op");
+        }
+    }
+
+    @Test
+    void noFormulasAreWrittenWhenThereAreNoVisibleBoundaryColumns() throws Exception {
+        try (XSSFWorkbook wb = workbookWithLayout()) {
+            List<Integer> none = java.util.Collections.emptyList();
+            invoke(wb, new HierarchicalBoundaryUtil.BoundaryColumnLayout(
+                    CODE_COL, none, MAPPING_START, MAPPING_END));
+            assertNull(wb.getSheet(SHEET).getRow(2), "no boundary levels means nothing to resolve from");
+        }
+    }
+
+    @Test
+    void theLayoutDoesNotExposeItsCallersMutableList() {
+        List<Integer> mutable = new java.util.ArrayList<>(Arrays.asList(COUNTRY_COL, STATE_COL));
+        HierarchicalBoundaryUtil.BoundaryColumnLayout layout = new HierarchicalBoundaryUtil.BoundaryColumnLayout(
+                CODE_COL, mutable, MAPPING_START, MAPPING_END);
+        mutable.add(99);
+        assertEquals(2, layout.getVisibleBoundaryColIndices().size(), "layout must not track later mutation");
+    }
+
+    @Test
+    void theVlookupResultIndexIsDerivedFromTheMappingColumnsNotHardcoded() throws Exception {
+        stubRowLimit(5000);
+        try (XSSFWorkbook wb = workbookWithLayout()) {
+            invoke(wb, layout());
+            String formula = wb.getSheet(SHEET).getRow(2).getCell(CODE_COL).getCellFormula();
+            int expectedOffset = HierarchicalBoundaryUtil.CODE_MAPPING_CODE_COLUMN
+                    - HierarchicalBoundaryUtil.CODE_MAPPING_KEY_COLUMN + 1;
+            assertTrue(formula.contains("," + expectedOffset + ",0)"),
+                    "VLOOKUP index must follow the mapping columns, was: " + formula);
+        }
+    }
+
+    @Test
+    void theSharedBoundaryUtilStillAdvertisesTheMappingColumnsThisFormulaDependsOn() {
+        // Guards the coupling: the formula reads Section 2 via these two constants.
+        assertEquals(3, HierarchicalBoundaryUtil.CODE_MAPPING_KEY_COLUMN);
+        assertEquals(4, HierarchicalBoundaryUtil.CODE_MAPPING_CODE_COLUMN);
+        assertTrue(HierarchicalBoundaryUtil.LOOKUP_SHEET_NAME.startsWith("_h_"));
+    }
+}

--- a/health-services/excel-ingestion/src/test/java/org/egov/excelingestion/generator/AttendanceRegisterSheetGeneratorTest.java
+++ b/health-services/excel-ingestion/src/test/java/org/egov/excelingestion/generator/AttendanceRegisterSheetGeneratorTest.java
@@ -165,19 +165,6 @@ class AttendanceRegisterSheetGeneratorTest {
     }
 
     @Test
-    void fillSpansTheConfiguredExcelRowLimit() throws Exception {
-        stubRowLimit(10);
-        try (XSSFWorkbook wb = workbookWithLayout()) {
-            invoke(wb, layout());
-
-            Sheet sheet = wb.getSheet(SHEET);
-            assertEquals(CellType.FORMULA, sheet.getRow(2).getCell(REGISTER_ID_COL).getCellType());
-            assertEquals(CellType.FORMULA, sheet.getRow(10).getCell(REGISTER_ID_COL).getCellType());
-            assertNull(sheet.getRow(11), "fill must stop at excelRowLimit");
-        }
-    }
-
-    @Test
     void noFormulasAreWrittenWhenThereIsNoBoundaryCodeMapping() throws Exception {
         try (XSSFWorkbook wb = workbookWithLayout()) {
             invoke(wb, new HierarchicalBoundaryUtil.BoundaryColumnLayout(
@@ -233,6 +220,67 @@ class AttendanceRegisterSheetGeneratorTest {
                     - HierarchicalBoundaryUtil.CODE_MAPPING_KEY_COLUMN + 1;
             assertTrue(formula.contains("," + expectedOffset + ",0)"),
                     "VLOOKUP index must follow the mapping columns, was: " + formula);
+        }
+    }
+
+    @Test
+    void theLastDropdownRowAlsoGetsFormulas() throws Exception {
+        // Dropdowns span row indices 2..excelRowLimit + 1; a covered row without the formula would
+        // yield a blank code and be rejected on upload with "Boundary code is missing".
+        int rowLimit = 10;
+        stubRowLimit(rowLimit);
+        try (XSSFWorkbook wb = workbookWithLayout()) {
+            invoke(wb, layout());
+
+            Sheet sheet = wb.getSheet(SHEET);
+            Row lastRow = sheet.getRow(rowLimit + 1);
+            assertEquals(CellType.FORMULA, lastRow.getCell(CODE_COL).getCellType(),
+                    "last validation row must carry the code formula");
+            assertEquals(CellType.FORMULA, lastRow.getCell(REGISTER_ID_COL).getCellType());
+
+            // Cell type alone would pass even if the formula referenced the wrong row, so resolve it.
+            lastRow.createCell(COUNTRY_COL).setCellValue("Nigeria");
+            lastRow.createCell(STATE_COL).setCellValue("Oyo");
+            FormulaEvaluator evaluator = wb.getCreationHelper().createFormulaEvaluator();
+            assertEquals(STATE_CODE, evaluatedString(evaluator, lastRow.getCell(CODE_COL)));
+            assertEquals(STATE_CODE, evaluatedString(evaluator, lastRow.getCell(REGISTER_ID_COL)));
+
+            assertNull(sheet.getRow(rowLimit + 2), "fill must not go past the validation range");
+        }
+    }
+
+    @Test
+    void registerIdIsBlankRatherThanZeroWhenTheCodeCellItselfIsBlank() throws Exception {
+        stubRowLimit(5000);
+        try (XSSFWorkbook wb = workbookWithLayout()) {
+            invoke(wb, layout());
+
+            // Simulate a code cell with no formula at all (the failure mode a bare =<code><row> hit):
+            // a bare reference to a blank cell evaluates to NUMERIC 0, which was the reported symptom.
+            Row row = wb.getSheet(SHEET).getRow(2);
+            row.getCell(CODE_COL).setBlank();
+
+            FormulaEvaluator evaluator = wb.getCreationHelper().createFormulaEvaluator();
+            assertEquals("", evaluatedString(evaluator, row.getCell(REGISTER_ID_COL)),
+                    "Register ID must be blank-safe independently of the code column");
+        }
+    }
+
+    @Test
+    void prefilledCodeAndRegisterIdValuesAreNotOverwrittenByFormulas() throws Exception {
+        stubRowLimit(5000);
+        try (XSSFWorkbook wb = workbookWithLayout()) {
+            Sheet sheet = wb.getSheet(SHEET);
+            Row prefilled = sheet.createRow(2);
+            prefilled.createCell(CODE_COL).setCellValue("SERVER_AUTHORITATIVE_CODE");
+            prefilled.createCell(REGISTER_ID_COL).setCellValue("Reg2201");
+
+            invoke(wb, layout());
+
+            assertEquals("SERVER_AUTHORITATIVE_CODE", sheet.getRow(2).getCell(CODE_COL).getStringCellValue());
+            assertEquals("Reg2201", sheet.getRow(2).getCell(REGISTER_ID_COL).getStringCellValue());
+            // The untouched row below still gets its formulas.
+            assertEquals(CellType.FORMULA, sheet.getRow(3).getCell(CODE_COL).getCellType());
         }
     }
 


### PR DESCRIPTION
The "excel size fix" (76869fca836) made boundary templates scaffold-less,
  deleting the per-row VLOOKUP that filled the hidden boundary-code column
  client-side. Two consumers were missed:

  - The attendance Register ID formula is =<boundaryCodeCol><row>. Pointing at
    a now-blank cell renders 0 in Excel.
  - Nothing fills the code column for attendance uploads, since project-factory
    parses those sheets itself instead of routing them through excel-ingestion.
    Every row failed with "Boundary code is missing" and no register was created.

  Restore the lookup, scoped to the attendance template only:

  - HierarchicalBoundaryUtil returns a BoundaryColumnLayout (code column index,
    visible level columns, lookup-sheet Section-2 row bounds) instead of void.
    The row range was already computed and merely logged. Additive only - no
    formulas are written there, so facility/user/unified-console templates are
    byte-identical and keep the size win.
  - AttendanceRegisterSheetGenerator writes the per-row code lookup itself and
    points Register ID at it, unlocked so a user can type their own id over it.
    Blank until a boundary is selected; IFERROR keeps an out-of-dropdown value
    blank rather than #N/A.

  The 6 *_HELPER columns are deliberately NOT recreated - the cascade resolves
  inside each validation formula now, which was ~half the old scaffold cost. The
  formula is built once as a template and stamped per row, and the VLOOKUP result
  index is derived from the mapping-column constants rather than hardcoded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved attendance-register spreadsheet formulas to reliably derive boundary codes from hierarchical selections.
  * Register IDs now reflect the deepest selected boundary and fall back to parent-level selections when needed.
  * Register ID cells remain editable for manual overrides.
  * Empty or invalid boundary selections now produce blank values instead of incorrect results.
  * Formula generation respects the configured spreadsheet row limit and handles missing boundary mappings safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->