### PR TITLE
fix(excel-ingestion): skip campaign clone resolution for register references

### DIFF
--- a/health-services/excel-ingestion/src/main/java/org/egov/excelingestion/service/ImmutableJoinService.java
+++ b/health-services/excel-ingestion/src/main/java/org/egov/excelingestion/service/ImmutableJoinService.java
@@ -155,12 +155,19 @@ public class ImmutableJoinService {
         // equality check would falsely reject every legitimate upload. The generationId (unguessable,
         // looked up by id + tenant) plus the referenceId match are the identity guarantee.
 
-        CampaignSearchResponse.CampaignDetail campaign = campaignService.searchCampaignById(
-                resource.getReferenceId(), resource.getTenantId(), requestInfo);
-        String clonedCampaignId = campaign.getAdditionalDetails() == null ? null
-                : campaign.getAdditionalDetails().getClonedCampaignId();
-        log.info("Immutable-baseline join for generationId {}: campaign {} clonedCampaignId {}",
-                generationId, resource.getReferenceId(), clonedCampaignId);
+        // A register reference is not a campaign id, so clone resolution is skipped for it.
+        String clonedCampaignId = null;
+        if (ProcessingConstants.REFERENCE_TYPE_ATTENDANCE_REGISTER.equals(resource.getReferenceType())) {
+            log.info("Immutable-baseline join for generationId {}: register reference {}, no clone resolution",
+                    generationId, resource.getReferenceId());
+        } else {
+            CampaignSearchResponse.CampaignDetail campaign = campaignService.searchCampaignById(
+                    resource.getReferenceId(), resource.getTenantId(), requestInfo);
+            clonedCampaignId = campaign.getAdditionalDetails() == null ? null
+                    : campaign.getAdditionalDetails().getClonedCampaignId();
+            log.info("Immutable-baseline join for generationId {}: campaign {} clonedCampaignId {}",
+                    generationId, resource.getReferenceId(), clonedCampaignId);
+        }
 
 
 

--- a/health-services/excel-ingestion/src/test/java/org/egov/excelingestion/service/ImmutableJoinServiceTest.java
+++ b/health-services/excel-ingestion/src/test/java/org/egov/excelingestion/service/ImmutableJoinServiceTest.java
@@ -528,7 +528,7 @@ class ImmutableJoinServiceTest {
 
             ProcessResource attendee = ProcessResource.builder()
                     .tenantId(TENANT).type("attendanceRegisterAttendee-validation")
-                    .referenceId(REF).referenceType("attendanceRegister")
+                    .referenceId(REF).referenceType(ProcessingConstants.REFERENCE_TYPE_ATTENDANCE_REGISTER)
                     .fileStoreId(UPLOAD_FS).build();
 
             Map<String, Object> up = row(ROW_ID, "r1", "name", "HACKED");
@@ -554,7 +554,7 @@ class ImmutableJoinServiceTest {
 
             ProcessResource cloned = ProcessResource.builder()
                     .tenantId(TENANT).type(TYPE).referenceId("campaign-2")
-                    .referenceType("campaign").fileStoreId(UPLOAD_FS).build();
+                    .referenceType(ProcessingConstants.REFERENCE_TYPE_CAMPAIGN).fileStoreId(UPLOAD_FS).build();
 
             Map<String, Object> up = row(ROW_ID, "r1", "name", "HACKED");
             Map<String, Object> base = row(ROW_ID, "r1", "name", "Real Name");

--- a/health-services/excel-ingestion/src/test/java/org/egov/excelingestion/service/ImmutableJoinServiceTest.java
+++ b/health-services/excel-ingestion/src/test/java/org/egov/excelingestion/service/ImmutableJoinServiceTest.java
@@ -518,6 +518,54 @@ class ImmutableJoinServiceTest {
             assertEquals("Real Name", up.get("name"), "attendanceRegisterAttendee type is in join scope -> immutable restored");
         }
 
+        @Test
+        void attendeeUpload_withRegisterReference_doesNotResolveReferenceAsCampaign() {
+            // Attendee uploads send referenceType "attendanceRegister" and a REGISTER id. Resolving that
+            // as a campaign throws CAMPAIGN_NOT_FOUND and blocks every attendee upload, so the lookup
+            // must be skipped entirely for non-campaign references.
+            lenient().when(campaignService.searchCampaignById(anyString(), anyString(), any()))
+                    .thenThrow(new RuntimeException("Campaign not found with ID: register-1"));
+
+            ProcessResource attendee = ProcessResource.builder()
+                    .tenantId(TENANT).type("attendanceRegisterAttendee-validation")
+                    .referenceId(REF).referenceType("attendanceRegister")
+                    .fileStoreId(UPLOAD_FS).build();
+
+            Map<String, Object> up = row(ROW_ID, "r1", "name", "HACKED");
+            Map<String, Object> base = row(ROW_ID, "r1", "name", "Real Name");
+            stubRows(new ArrayList<>(List.of(up)), new ArrayList<>(List.of(base)));
+
+            service.applyImmutableBaseline(uploadedWorkbook, attendee, sheetNameToSchema, null);
+
+            assertEquals("Real Name", up.get("name"), "attendee upload must join without a campaign lookup");
+            verify(campaignService, never()).searchCampaignById(anyString(), anyString(), any());
+        }
+
+        @Test
+        void campaignReference_stillResolvesClonedCampaign() {
+            // The clone fix must keep working for campaign references: the baseline belongs to the
+            // campaign this one was cloned FROM, not to this campaign's own id.
+            when(campaignService.searchCampaignById(anyString(), anyString(), any()))
+                    .thenReturn(CampaignSearchResponse.CampaignDetail.builder()
+                            .id("campaign-2").tenantId(TENANT)
+                            .additionalDetails(CampaignSearchResponse.AdditionalDetails.builder()
+                                    .clonedCampaignId(REF).build())
+                            .build());
+
+            ProcessResource cloned = ProcessResource.builder()
+                    .tenantId(TENANT).type(TYPE).referenceId("campaign-2")
+                    .referenceType("campaign").fileStoreId(UPLOAD_FS).build();
+
+            Map<String, Object> up = row(ROW_ID, "r1", "name", "HACKED");
+            Map<String, Object> base = row(ROW_ID, "r1", "name", "Real Name");
+            stubRows(new ArrayList<>(List.of(up)), new ArrayList<>(List.of(base)));
+
+            service.applyImmutableBaseline(uploadedWorkbook, cloned, sheetNameToSchema, null);
+
+            assertEquals("Real Name", up.get("name"), "cloned campaign baseline must still be accepted");
+            verify(campaignService).searchCampaignById(anyString(), anyString(), any());
+        }
+
         private void removeMetaSheet() {
             uploadedWorkbook.removeSheetAt(uploadedWorkbook.getSheetIndex(GenerationConstants.META_SHEET_NAME));
         }


### PR DESCRIPTION
Root cause: Newly introduced immutable join was validating reference ID with campaign ID to process the clone campaign correctly. But this is not valid for attendance, so we are skipping that with reference type check when equals to attendanceRegister, so that , that change remains specific to campaign creation and unblocks attendance flow.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attendance-register upload processing by skipping unnecessary campaign resolution.
  * Preserved immutable baseline values during attendance-register joins.
  * Continued resolving cloned campaign references for other upload types.

* **Tests**
  * Added coverage for attendance-register and campaign-based reference handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->