### PR TITLE
feat(product): peopleInHouseholds and itnsDistributed in summary report

### DIFF
--- a/health-services/product/src/main/java/org/egov/product/summaryreport/repository/SummaryReportRepository.java
+++ b/health-services/product/src/main/java/org/egov/product/summaryreport/repository/SummaryReportRepository.java
@@ -1,5 +1,7 @@
 package org.egov.product.summaryreport.repository;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.egov.common.exception.InvalidTenantIdException;
 import org.egov.common.utils.MultiStateInstanceUtil;
@@ -110,9 +112,35 @@ public class SummaryReportRepository {
         return result;
     }
 
-    public Map<String, Long> householdsRegisteredByDay(String createdBy, String tenantId,
-                                                        Long startDate, Long endDate) {
-        return countByDay("household", createdBy, tenantId, startDate, endDate);
+    /** One day's household aggregates: registrations plus the occupants recorded across them. */
+    @Getter
+    @AllArgsConstructor
+    public static class HouseholdDayAggregate {
+        private final long householdsRegistered;
+        private final long peopleInHouseholds;
+    }
+
+    /**
+     * Households registered per day together with SUM({@code numberOfMembers}) across those
+     * same households. Both aggregates come from one scan of the same rows, so this costs
+     * no more than the plain count did. {@code numberOfMembers} is nullable, hence COALESCE.
+     */
+    public Map<String, HouseholdDayAggregate> householdsRegisteredByDay(String createdBy, String tenantId,
+                                                                        Long startDate, Long endDate) {
+        String sql = "SELECT " + dayExpr(tenantId) + " AS day, COUNT(*) AS cnt, "
+                + "COALESCE(SUM(numberofmembers), 0) AS members "
+                + "FROM " + SCHEMA_REPLACE_STRING + ".household "
+                + "WHERE createdby = :createdBy "
+                + "AND tenantid = :tenantId "
+                + "AND (isdeleted = false OR isdeleted IS NULL) "
+                + "AND createdtime >= :startDate AND createdtime <= :endDate "
+                + "GROUP BY day";
+        sql = resolveSchema(sql, tenantId);
+        Map<String, HouseholdDayAggregate> result = new HashMap<>();
+        jdbcTemplate.query(sql, baseParams(createdBy, tenantId, startDate, endDate),
+                (RowCallbackHandler) rs -> result.put(rs.getString("day"),
+                        new HouseholdDayAggregate(rs.getLong("cnt"), rs.getLong("members"))));
+        return result;
     }
 
     public Map<String, Long> individualRegisteredByDay(String createdBy, String tenantId,

--- a/health-services/product/src/main/java/org/egov/product/summaryreport/service/SummaryReportService.java
+++ b/health-services/product/src/main/java/org/egov/product/summaryreport/service/SummaryReportService.java
@@ -53,9 +53,13 @@ public class SummaryReportService {
         // day -> summary; TreeMap keeps the array ordered by date ascending.
         Map<String, DailyReportSummary> byDay = new TreeMap<>();
 
-        mergeCounts(byDay, createdBy,
-                repository.householdsRegisteredByDay(createdBy, tenantId, startDate, endDate),
-                DailyReportSummary::setHouseholdsRegistered);
+        // Households carry two metrics off one query, so they merge separately from the rest.
+        repository.householdsRegisteredByDay(createdBy, tenantId, startDate, endDate)
+                .forEach((day, aggregate) -> {
+                    DailyReportSummary summary = getOrCreate(byDay, day, createdBy);
+                    summary.setHouseholdsRegistered(aggregate.getHouseholdsRegistered());
+                    summary.setPeopleInHouseholds(aggregate.getPeopleInHouseholds());
+                });
         mergeCounts(byDay, createdBy,
                 repository.individualRegisteredByDay(createdBy, tenantId, startDate, endDate),
                 DailyReportSummary::setIndividualRegistered);
@@ -68,8 +72,12 @@ public class SummaryReportService {
 
         Map<String, Map<String, Long>> stockByDay =
                 repository.stockConsumedByDay(createdBy, tenantId, startDate, endDate);
-        stockByDay.forEach((day, stockMap) ->
-                getOrCreate(byDay, day, createdBy).setStockConsumedMap(stockMap));
+        stockByDay.forEach((day, stockMap) -> {
+            DailyReportSummary summary = getOrCreate(byDay, day, createdBy);
+            summary.setStockConsumedMap(stockMap);
+            // Nets only on this campaign, so every variant in the map counts toward the total.
+            summary.setItnsDistributed(stockMap.values().stream().mapToLong(Long::longValue).sum());
+        });
 
         return new ArrayList<>(byDay.values());
     }

--- a/health-services/product/src/main/java/org/egov/product/summaryreport/web/models/DailyReportSummary.java
+++ b/health-services/product/src/main/java/org/egov/product/summaryreport/web/models/DailyReportSummary.java
@@ -36,6 +36,15 @@ public class DailyReportSummary {
     @Builder.Default
     private Long householdsRegistered = 0L;
 
+    /**
+     * Total occupants recorded across the households registered that day, i.e. the sum of
+     * {@code household.numberOfMembers}. This is the household size the worker entered at
+     * registration, which may exceed the number of members actually enrolled individually.
+     */
+    @JsonProperty("peopleInHouseholds")
+    @Builder.Default
+    private Long peopleInHouseholds = 0L;
+
     @JsonProperty("individualRegistered")
     @Builder.Default
     private Long individualRegistered = 0L;
@@ -47,6 +56,15 @@ public class DailyReportSummary {
     @JsonProperty("childrenTreated")
     @Builder.Default
     private Long childrenTreated = 0L;
+
+    /**
+     * Total ITNs handed out that day, i.e. the sum of every quantity in
+     * {@link #stockConsumedMap}. The campaign distributes nets only, so the flat total and
+     * the per-variant breakdown describe the same stock from two angles.
+     */
+    @JsonProperty("itnsDistributed")
+    @Builder.Default
+    private Long itnsDistributed = 0L;
 
     /** productVariantId -> quantity consumed (delivered) that day. */
     @JsonProperty("stockConsumedMap")

--- a/health-services/product/src/test/java/org/egov/product/summaryreport/repository/SummaryReportRepositoryIT.java
+++ b/health-services/product/src/test/java/org/egov/product/summaryreport/repository/SummaryReportRepositoryIT.java
@@ -131,6 +131,7 @@ class SummaryReportRepositoryIT {
         List<DailyReportSummary> report = service.getDailySummary(req(tenant, createdBy));
 
         long households = report.stream().mapToLong(DailyReportSummary::getHouseholdsRegistered).sum();
+        long people = report.stream().mapToLong(DailyReportSummary::getPeopleInHouseholds).sum();
         long children = report.stream().mapToLong(DailyReportSummary::getIndividualRegistered).sum();
         long beneficiaries = report.stream().mapToLong(DailyReportSummary::getBeneficiariesRegistered).sum();
         long treated = report.stream().mapToLong(DailyReportSummary::getChildrenTreated).sum();
@@ -138,15 +139,19 @@ class SummaryReportRepositoryIT {
                 .flatMap(d -> d.getStockConsumedMap().values().stream())
                 .mapToLong(Long::longValue).sum();
 
-        System.out.printf("[%s / %s] days=%d households=%d children=%d beneficiaries=%d treated=%d stockQty=%d%n",
-                tenant, createdBy, report.size(), households, children, beneficiaries, treated, stock);
+        System.out.printf("[%s / %s] days=%d households=%d people=%d children=%d beneficiaries=%d treated=%d stockQty=%d%n",
+                tenant, createdBy, report.size(), households, people, children, beneficiaries, treated, stock);
 
         assertEquals(directCount(tenant, "household", createdBy, ""), households, "households");
+        assertEquals(directSum(tenant, "household", "numberofmembers", createdBy, ""), people, "peopleInHouseholds");
         assertEquals(directCount(tenant, "individual", createdBy, ""), children, "children");
         assertEquals(directCount(tenant, "project_beneficiary", createdBy, ""), beneficiaries, "beneficiaries");
         assertEquals(directCount(tenant, "project_task", createdBy,
                 " AND status IN ('ADMINISTRATION_SUCCESS','VISITED') "), treated, "treated");
         assertEquals(directStock(tenant, createdBy), stock, "stockQty");
+        // itnsDistributed is the flattened stockConsumedMap, so the two must never diverge.
+        assertEquals(stock, report.stream().mapToLong(DailyReportSummary::getItnsDistributed).sum(),
+                "itnsDistributed should equal the total of stockConsumedMap");
     }
 
     @Test

--- a/health-services/product/src/test/java/org/egov/product/summaryreport/service/SummaryReportServiceTest.java
+++ b/health-services/product/src/test/java/org/egov/product/summaryreport/service/SummaryReportServiceTest.java
@@ -4,6 +4,7 @@ import org.egov.common.contract.request.RequestInfo;
 import org.egov.common.helper.RequestInfoTestBuilder;
 import org.egov.product.summaryreport.config.SummaryReportConfiguration;
 import org.egov.product.summaryreport.repository.SummaryReportRepository;
+import org.egov.product.summaryreport.repository.SummaryReportRepository.HouseholdDayAggregate;
 import org.egov.product.summaryreport.web.models.DailyReportSummary;
 import org.egov.product.summaryreport.web.models.SummaryReportSearchCriteria;
 import org.egov.product.summaryreport.web.models.SummaryReportSearchRequest;
@@ -95,9 +96,9 @@ class SummaryReportServiceTest {
     @Test
     @DisplayName("should merge all five metrics by day, ordered ascending, defaulting missing metrics to 0")
     void shouldMergeMetricsByDay() {
-        Map<String, Long> households = new HashMap<>();
-        households.put("2026-07-17", 5L);
-        households.put("2026-07-18", 3L);
+        Map<String, HouseholdDayAggregate> households = new HashMap<>();
+        households.put("2026-07-17", new HouseholdDayAggregate(5L, 23L));
+        households.put("2026-07-18", new HouseholdDayAggregate(3L, 11L));
         when(repository.householdsRegisteredByDay(eq(UUID), eq(TENANT), anyLong(), anyLong())).thenReturn(households);
 
         when(repository.childrenTreatedByDay(eq(UUID), eq(TENANT), anyLong(), anyLong()))
@@ -118,16 +119,20 @@ class SummaryReportServiceTest {
         assertEquals("2026-07-17", d17.getDate());
         assertEquals(UUID, d17.getCreatedBy());
         assertEquals(5L, d17.getHouseholdsRegistered());
+        assertEquals(23L, d17.getPeopleInHouseholds());
         assertEquals(0L, d17.getChildrenTreated());
         assertEquals(0L, d17.getIndividualRegistered());
         assertEquals(2, d17.getStockConsumedMap().size());
         assertEquals(10L, d17.getStockConsumedMap().get("pv-1"));
+        assertEquals(14L, d17.getItnsDistributed(), "itnsDistributed should total every variant");
 
         DailyReportSummary d18 = result.get(1);
         assertEquals("2026-07-18", d18.getDate());
         assertEquals(3L, d18.getHouseholdsRegistered());
+        assertEquals(11L, d18.getPeopleInHouseholds());
         assertEquals(7L, d18.getChildrenTreated());
         assertTrue(d18.getStockConsumedMap().isEmpty());
+        assertEquals(0L, d18.getItnsDistributed(), "a day with no stock should report 0, not null");
     }
 
     @Test
@@ -142,7 +147,7 @@ class SummaryReportServiceTest {
     @DisplayName("should resolve employee from RequestInfo.userInfo.uuid")
     void shouldUseUuidFromRequestInfo() {
         when(repository.householdsRegisteredByDay(eq(UUID), eq(TENANT), anyLong(), anyLong()))
-                .thenReturn(Collections.singletonMap("2026-07-18", 1L));
+                .thenReturn(Collections.singletonMap("2026-07-18", new HouseholdDayAggregate(1L, 4L)));
 
         List<DailyReportSummary> result =
                 summaryReportService.getDailySummary(request(completeRequestInfo(), validCriteria()));


### PR DESCRIPTION
Two additive fields on DailyReportSummary:

- peopleInHouseholds: SUM(household.numberofmembers) across the households registered that day. Computed in the same GROUP BY scan as householdsRegistered, so it costs no extra query. This is the household size the worker entered at registration, which may exceed individualRegistered when occupants are recorded but not enrolled.

- itnsDistributed: flat total of every quantity in stockConsumedMap. The campaign distributes nets only, so the total and the per-variant breakdown describe the same stock from two angles.

householdsRegisteredByDay now returns a HouseholdDayAggregate instead of a plain count, so the service merges households separately from the other metrics. Both fields default to 0 rather than null, so a day with no stock reports 0. No field renamed or removed